### PR TITLE
fix: sleep in async executor when there are no futures left to poll

### DIFF
--- a/pros/src/async_runtime/executor.rs
+++ b/pros/src/async_runtime/executor.rs
@@ -89,13 +89,4 @@ impl Executor {
             self.tick();
         }
     }
-
-    pub fn complete(&self) {
-        loop {
-            if !self.tick() {
-                break;
-            }
-            delay(Duration::from_millis(10));
-        }
-    }
 }

--- a/pros/src/async_runtime/executor.rs
+++ b/pros/src/async_runtime/executor.rs
@@ -4,13 +4,14 @@ use core::{
     pin::Pin,
     sync::atomic::{AtomicBool, Ordering},
     task::{Context, Poll},
+    time::Duration,
 };
 
 use alloc::{collections::VecDeque, sync::Arc};
 use async_task::{Runnable, Task};
 use waker_fn::waker_fn;
 
-use crate::os_task_local;
+use crate::{os_task_local, task::delay};
 
 use super::reactor::Reactor;
 
@@ -82,6 +83,7 @@ impl Executor {
             }
 
             self.tick();
+            delay(Duration::from_millis(10));
         }
     }
 
@@ -90,6 +92,7 @@ impl Executor {
             if !self.tick() {
                 break;
             }
+            delay(Duration::from_millis(10));
         }
     }
 }

--- a/pros/src/async_runtime/executor.rs
+++ b/pros/src/async_runtime/executor.rs
@@ -80,10 +80,13 @@ impl Executor {
                 if let Poll::Ready(output) = Pin::new(&mut task).poll(&mut cx) {
                     return output;
                 }
+                self.tick();
+                // there might be another future to poll, so we continue without sleeping
+                continue;
             }
 
-            self.tick();
             delay(Duration::from_millis(10));
+            self.tick();
         }
     }
 

--- a/pros/src/async_runtime/mod.rs
+++ b/pros/src/async_runtime/mod.rs
@@ -22,11 +22,3 @@ pub fn spawn<T>(future: impl Future<Output = T> + 'static) -> Task<T> {
 pub fn block_on<F: Future + 'static>(future: F) -> F::Output {
     executor::EXECUTOR.with(|e| e.block_on(spawn(future)))
 }
-
-/// Completes all tasks.
-/// Return values can be extracted from the futures by awaiting any [`Task`]s you have not detached.
-pub fn complete_all() {
-    executor::EXECUTOR.with(|e| {
-        e.complete();
-    })
-}

--- a/pros/src/lib.rs
+++ b/pros/src/lib.rs
@@ -185,7 +185,6 @@ macro_rules! __gen_async_exports {
                     .expect("Expected initialize to run before opcontrol")
             }))
             .unwrap();
-            $crate::async_runtime::complete_all();
         }
 
         #[doc(hidden)]
@@ -197,7 +196,6 @@ macro_rules! __gen_async_exports {
                     .expect("Expected initialize to run before auto")
             }))
             .unwrap();
-            $crate::async_runtime::complete_all();
         }
 
         #[doc(hidden)]
@@ -209,7 +207,6 @@ macro_rules! __gen_async_exports {
                     .expect("Expected initialize to run before disabled")
             }))
             .unwrap();
-            $crate::async_runtime::complete_all();
         }
 
         #[doc(hidden)]
@@ -221,7 +218,6 @@ macro_rules! __gen_async_exports {
                     .expect("Expected initialize to run before comp_init")
             }))
             .unwrap();
-            $crate::async_runtime::complete_all();
         }
     };
 }


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

The async executor now sleeps when there are no futures left for it to poll. 
This stops it from completely starving the OS even when the user has awaited a sleep future.
The `complete_all` function has also been removed because it was broken and could not easily be fixed. 

## Additional Context

This has been tested in the simulator and on a real V5 Brain.