### PR TITLE
feat: Reimplement `std::time::Instant`

### DIFF
--- a/pros/src/lib.rs
+++ b/pros/src/lib.rs
@@ -80,8 +80,8 @@ pub mod battery;
 pub mod competition;
 pub mod link;
 pub mod lvgl;
-pub mod usd;
 pub mod time;
+pub mod usd;
 
 pub use async_trait::async_trait;
 

--- a/pros/src/lib.rs
+++ b/pros/src/lib.rs
@@ -81,6 +81,7 @@ pub mod competition;
 pub mod link;
 pub mod lvgl;
 pub mod usd;
+pub mod time;
 
 pub use async_trait::async_trait;
 

--- a/pros/src/time.rs
+++ b/pros/src/time.rs
@@ -1,0 +1,117 @@
+use core::{
+    time::Duration,
+    fmt,
+    ops::{Add, AddAssign, Sub, SubAssign}
+};
+
+/// Represents a timestamp on a monotonically nondecreasing clock relative to the
+/// start of the user program.
+/// 
+/// This type has a precision of 1 microsecond.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Instant(u64);
+
+impl Instant {
+    /// Returns an instant corresponding to "now".
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use pros::time::Instant;
+    ///
+    /// let now = Instant::now();
+    /// ```
+    pub fn now() -> Self {
+        Self(unsafe { pros_sys::rtos::micros() })
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one,
+    /// or zero duration if that instant is later than this one.
+    pub fn duration_since(&self, earlier: Instant) -> Duration {
+        self.checked_duration_since(earlier).unwrap_or_default()
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one,
+    /// or None if that instant is later than this one.
+    pub fn checked_duration_since(&self, earlier: Instant) -> Option<Duration> {
+        if earlier.0 < self.0 {
+            Some(Duration::from_micros(self.0 - earlier.0))
+        } else {
+            None
+        }
+    }
+
+	/// Returns the amount of time elapsed from another instant to this one,
+    /// or None if that instant is later than this one.
+	pub fn saturating_duration_since(&self, earlier: Instant) -> Duration {
+        self.checked_duration_since(earlier).unwrap_or_default()
+    }
+
+    /// Returns the amount of time elapsed since this instant.
+    pub fn elapsed(&self) -> Duration {
+        Instant::now() - *self
+    }
+
+    /// Returns `Some(t)` where `t` is the time `self + duration` if `t` can be represented as
+    /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
+    /// otherwise.
+    pub fn checked_add(self, rhs: Duration) -> Option<Instant> {
+        Some(Self(self.0.checked_add(rhs.as_micros().try_into().ok()?)?))
+    }
+
+    /// Returns `Some(t)` where `t` is the time `self - duration` if `t` can be represented as
+    /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
+    /// otherwise.
+    pub fn checked_sub(self, rhs: Duration) -> Option<Instant> {
+        Some(Self(self.0.checked_sub(rhs.as_micros().try_into().ok()?)?))
+    }
+}
+
+impl Add<Duration> for Instant {
+    type Output = Instant;
+
+    /// # Panics
+    ///
+    /// This function may panic if the resulting point in time cannot be represented by the
+    /// underlying data structure. See [`Instant::checked_add`] for a version without panic.
+    fn add(self, rhs: Duration) -> Self::Output {
+        self.checked_add(rhs)
+            .expect("overflow when adding duration to instant")
+    }
+}
+
+impl AddAssign<Duration> for Instant {
+    fn add_assign(&mut self, other: Duration) {
+        *self = *self + other;
+    }
+}
+
+impl Sub<Duration> for Instant {
+    type Output = Instant;
+
+    fn sub(self, other: Duration) -> Instant {
+        self.checked_sub(other).expect("overflow when subtracting duration from instant")
+    }
+}
+
+impl SubAssign<Duration> for Instant {
+    fn sub_assign(&mut self, other: Duration) {
+        *self = *self - other;
+    }
+}
+
+impl Sub<Instant> for Instant {
+    type Output = Duration;
+
+    /// Returns the amount of time elapsed from another instant to this one,
+    /// or zero duration if that instant is later than this one.
+    fn sub(self, other: Instant) -> Duration {
+        self.duration_since(other)
+    }
+}
+
+impl fmt::Debug for Instant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/pros/src/time.rs
+++ b/pros/src/time.rs
@@ -1,3 +1,5 @@
+//! Temporal quantification.
+
 use core::{
     fmt,
     ops::{Add, AddAssign, Sub, SubAssign},
@@ -7,7 +9,8 @@ use core::{
 /// Represents a timestamp on a monotonically nondecreasing clock relative to the
 /// start of the user program.
 ///
-/// This type has a precision of 1 microsecond.
+/// # Precision
+/// This type has a precision of 1 microsecond, and uses [`pros_sys::micros`] internally.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Instant(u64);
 
@@ -27,12 +30,38 @@ impl Instant {
 
     /// Returns the amount of time elapsed from another instant to this one,
     /// or zero duration if that instant is later than this one.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use core::time::Duration;
+    /// use pros::{time::Instant, task::delay};
+    ///
+    /// let now = Instant::now();
+    /// delay(Duration::new(1, 0));
+    /// let new_now = Instant::now();
+    /// println!("{:?}", new_now.duration_since(now));
+    /// println!("{:?}", now.duration_since(new_now)); // 0ns
+    /// ```
     pub fn duration_since(&self, earlier: Instant) -> Duration {
         self.checked_duration_since(earlier).unwrap_or_default()
     }
 
     /// Returns the amount of time elapsed from another instant to this one,
     /// or None if that instant is later than this one.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use core::time::Duration;
+    /// use pros::{time::Instant, task::delay};
+    ///
+    /// let now = Instant::now();
+    /// delay(Duration::new(1, 0));
+    /// let new_now = Instant::now();
+    /// println!("{:?}", new_now.checked_duration_since(now));
+    /// println!("{:?}", now.checked_duration_since(new_now)); // None
+    /// ```
     pub fn checked_duration_since(&self, earlier: Instant) -> Option<Duration> {
         if earlier.0 < self.0 {
             Some(Duration::from_micros(self.0 - earlier.0))
@@ -43,11 +72,35 @@ impl Instant {
 
     /// Returns the amount of time elapsed from another instant to this one,
     /// or zero duration if that instant is later than this one.
+    /// 
+    /// # Examples
+    /// 
+    /// ```no_run
+    /// use core::time::Duration;
+    /// use pros::{time::Instant, task::delay};
+    ///
+    /// let instant = Instant::now();
+    /// let three_secs = Duration::from_secs(3);
+    /// delay(three_secs);
+    /// assert!(instant.elapsed() >= three_secs);
+    /// ```
     pub fn saturating_duration_since(&self, earlier: Instant) -> Duration {
         self.checked_duration_since(earlier).unwrap_or_default()
     }
 
     /// Returns the amount of time elapsed since this instant.
+    /// 
+    /// # Examples
+    /// 
+    /// ```no_run
+    /// use core::time::Duration;
+    /// use pros::{time::Instant, task::delay};
+    ///
+    /// let instant = Instant::now();
+    /// let three_secs = Duration::from_secs(3);
+    /// delay(three_secs);
+    /// assert!(instant.elapsed() >= three_secs);
+    /// ```
     pub fn elapsed(&self) -> Duration {
         Instant::now() - *self
     }

--- a/pros/src/time.rs
+++ b/pros/src/time.rs
@@ -42,7 +42,7 @@ impl Instant {
     }
 
     /// Returns the amount of time elapsed from another instant to this one,
-    /// or None if that instant is later than this one.
+    /// or zero duration if that instant is later than this one.
     pub fn saturating_duration_since(&self, earlier: Instant) -> Duration {
         self.checked_duration_since(earlier).unwrap_or_default()
     }

--- a/pros/src/time.rs
+++ b/pros/src/time.rs
@@ -72,9 +72,9 @@ impl Instant {
 
     /// Returns the amount of time elapsed from another instant to this one,
     /// or zero duration if that instant is later than this one.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```no_run
     /// use core::time::Duration;
     /// use pros::{time::Instant, task::delay};
@@ -89,9 +89,9 @@ impl Instant {
     }
 
     /// Returns the amount of time elapsed since this instant.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```no_run
     /// use core::time::Duration;
     /// use pros::{time::Instant, task::delay};

--- a/pros/src/time.rs
+++ b/pros/src/time.rs
@@ -1,12 +1,12 @@
 use core::{
-    time::Duration,
     fmt,
-    ops::{Add, AddAssign, Sub, SubAssign}
+    ops::{Add, AddAssign, Sub, SubAssign},
+    time::Duration,
 };
 
 /// Represents a timestamp on a monotonically nondecreasing clock relative to the
 /// start of the user program.
-/// 
+///
 /// This type has a precision of 1 microsecond.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Instant(u64);
@@ -41,9 +41,9 @@ impl Instant {
         }
     }
 
-	/// Returns the amount of time elapsed from another instant to this one,
+    /// Returns the amount of time elapsed from another instant to this one,
     /// or None if that instant is later than this one.
-	pub fn saturating_duration_since(&self, earlier: Instant) -> Duration {
+    pub fn saturating_duration_since(&self, earlier: Instant) -> Duration {
         self.checked_duration_since(earlier).unwrap_or_default()
     }
 
@@ -90,7 +90,8 @@ impl Sub<Duration> for Instant {
     type Output = Instant;
 
     fn sub(self, other: Duration) -> Instant {
-        self.checked_sub(other).expect("overflow when subtracting duration from instant")
+        self.checked_sub(other)
+            .expect("overflow when subtracting duration from instant")
     }
 }
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Adds a microsecond-precision `Instant` reimplementation using `pros::c::micros` internally. Timers are commonly used for many purposes (benchmarking, autonomous routines, etc...). This makes it easier to implement them without juggling around unsafe `pros_sys` system-time related calls.

## Additional Context
- Closes #25.
- Most of these methods and docs have been directly dragged over from `std`.
- Currently **untested** on V5 hardware.