### PR TITLE
fix: `gps_set_offset` function signature

### DIFF
--- a/pros-sys/src/gps.rs
+++ b/pros-sys/src/gps.rs
@@ -77,7 +77,7 @@ extern "C" {
     \return 1 if the operation was successful or PROS_ERR if the operation
     failed, setting errno.
     */
-    pub fn gps_set_offset(port: u8, xOffset: f64, yOffset: f64);
+    pub fn gps_set_offset(port: u8, xOffset: f64, yOffset: f64) -> i32;
     /**
     Get the GPS's location relative to the center of turning/origin in meters.
 

--- a/pros/src/sensors/gps.rs
+++ b/pros/src/sensors/gps.rs
@@ -41,7 +41,7 @@ impl GpsSensor {
     }
 
     /// Sets the offset of the GPS sensor, relative to the sensor of turning, in meters.
-    pub fn set_offset(&self, x: f64, y: f64) -> Result<(), GpsError> {
+    pub fn set_offset(&mut self, x: f64, y: f64) -> Result<(), GpsError> {
         unsafe {
             bail_on!(PROS_ERR, pros_sys::gps_set_offset(self.port, x, y));
         }

--- a/pros/src/sensors/gps.rs
+++ b/pros/src/sensors/gps.rs
@@ -41,10 +41,11 @@ impl GpsSensor {
     }
 
     /// Sets the offset of the GPS sensor, relative to the sensor of turning, in meters.
-    pub fn set_offset(&self, x: f64, y: f64) {
+    pub fn set_offset(&self, x: f64, y: f64) -> Result<(), GpsError> {
         unsafe {
-            pros_sys::gps_set_offset(self.port, x, y);
+            bail_on!(PROS_ERR, pros_sys::gps_set_offset(self.port, x, y));
         }
+        Ok(())
     }
 
     /// Gets the possible error of the GPS sensor, in meters.


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Uses the correct function signature for `gps_set_offset` in the bindings. `gps_set_offset` [returns an i32](https://pros.cs.purdue.edu/v5/api/c/gps.html#gps-set-offset) for throwing error codes, but was treated as a void function in the bindings.

## Additional Context
- `GpsSensor::set_offset` now returns a `Result<(), GpsError>` like other setters typically would. 