### PR TITLE
fix(cargo): update config for wasm and remove runner

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,13 +1,11 @@
 [build]
 target = "./armv7a-vexos-eabi.json"
 
-[target.armv7a-vexos]
-runner = "python runner.py"
-
 [target.wasm32-unknown-unknown]
 rustflags = [
     "-Ctarget-feature=+atomics,+bulk-memory,+mutable-globals",
     "-Clink-arg=--shared-memory",
+    "-Clink-arg=--export-table",
 ]
 
 [unstable]


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

The flags for building for WASM and the runner for the vexos target are currently outdated. This also fixes the "unwrap on Err in tasks.rs" panic that can sometimes show up in the simulator.

## Additional Context
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
<!--
Move all applicable items out of the comment:
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
