### PR TITLE
feat(task-local): add cell integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Before releasing:
 - Various types from the `no_std_io` have are re-exported from this module to provide missing functionality from `std`. (#30)
 - Macros for printing to stdout (`println`, `print`, `eprintln`, etc...) (#30)
 - All ADI device bindings (#55)
+- `LocalKey` now has `Cell`/`RefCell`-specific methods for setting and taking values. (#42)
 
 ### Fixed
 
@@ -47,6 +48,7 @@ Before releasing:
 ### Removed
 
 - Removed several broken bindings in `pros_sys` relating to competition state. (#38) (**Breaking Change**)
+- `LocalKey` no longer implements `set` for non-`Cell`/`RefCell` stored values. (**Breaking change**) (#42)
 
 ## [0.6.0] - 2024-01-14
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This PR makes the task local API more closely resemble `std::thread::LocalKey`. It also resolves a memory leak caused by setting the task-local's value. However, if the task is deleted, there is still a memory leak.

## Additional Context
- I have tested these changes on a VEX V5 brain.
- These are breaking changes (semver: major).
- These changes update the crate's interface (e.g. functions/modules added or changed).

Fixes #31
<!--
Move all applicable items out of the comment:
- I have tested these changes in a simulator.
- These are *only* non-code changes (e.g. documentation, README.md).
-->
