### PR TITLE
feat: add unknown variant to PortError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Before releasing:
 - Various types from the `no_std_io` have are re-exported from this module to provide missing functionality from `std`. (#30)
 - Macros for printing to stdout (`println`, `print`, `eprintln`, etc...) (#30)
 - All ADI device bindings (#55)
+- Added `Unknown` variant to `PortError` for unknown `errno` values. (#43)
 
 ### Fixed
 
@@ -37,6 +38,7 @@ Before releasing:
 - Fixed error handling in IMU sensor bindings. (#37)
 - Fixed errors in doctests and examples throughout the crate. (#37)
 - Fixed Missing ERRNO and ADI config variants in pros-sys (#55)
+- Unknown `errno` values will no longer crash the program. (**Breaking change**) (#43)
 
 ### Changed
 

--- a/packages/pros/examples/basic.rs
+++ b/packages/pros/examples/basic.rs
@@ -10,6 +10,8 @@ impl AsyncRobot for Robot {
     async fn opcontrol(&mut self) -> pros::Result {
         println!("basic example");
 
+        Motor::new(25, BrakeMode::None).unwrap();
+
         Ok(())
     }
 }

--- a/packages/pros/src/adi/motor.rs
+++ b/packages/pros/src/adi/motor.rs
@@ -1,5 +1,3 @@
-use core::panic;
-
 use pros_sys::PROS_ERR;
 
 use crate::{

--- a/packages/pros/src/error.rs
+++ b/packages/pros/src/error.rs
@@ -28,23 +28,43 @@ macro_rules! map_errno {
     {
         $err_ty:ty { $($errno:pat => $err:expr),*$(,)? }
         $(inherit $base:ty;)?
+        $(unknown = $unknown:expr;)?
     } => {
         impl $crate::error::FromErrno for $err_ty {
-            fn from_errno(num: i32) -> Option<Self> {
+            fn try_from_errno(num: i32) -> Option<Self> {
                 #[allow(unused_imports)]
                 use pros_sys::error::*;
                 $(
                     // if the enum we're inheriting from can handle this errno, return it.
-                    if let Some(err) = <$base as $crate::error::FromErrno>::from_errno(num) {
+                    if let Some(err) = <$base as $crate::error::FromErrno>::try_from_errno(num) {
                         return Some(err.into());
                     }
                 )?
                 match num {
                     $($errno => Some($err),)*
                     // this function should only be called if errno is set
-                    0 => panic!("Expected error state in errno, found 0."),
+                    0 => panic!("PROS reported an error but none was found!"),
                     _ => None,
                 }
+            }
+            #[allow(unused, clippy::redundant_closure_call)]
+            fn unknown_variant(num: i32) -> Option<Self> {
+                $(
+                    if let Some(variant) = <$base as $crate::error::FromErrno>::unknown_variant(num) {
+                        return Some(variant.into());
+                    }
+                )?
+                #[allow(unused_mut)]
+                let mut variant = None;
+                $(
+                    variant = Some($unknown(num));
+                )?
+                variant
+            }
+            fn from_errno(num: i32) -> Self {
+                Self::try_from_errno(num)
+                    .unwrap_or_else(|| Self::unknown_variant(num)
+                        .unwrap_or_else(|| panic!("Unknown errno code {num}")))
             }
         }
     }
@@ -56,8 +76,7 @@ macro_rules! bail_errno {
     () => {{
         let errno = $crate::error::take_errno();
         if errno != 0 {
-            let err = $crate::error::FromErrno::from_errno(errno)
-                .unwrap_or_else(|| panic!("Unknown errno code {errno}"));
+            let err = $crate::error::FromErrno::from_errno(errno);
             return Err(err);
         }
     }};
@@ -72,8 +91,7 @@ macro_rules! bail_on {
         #[allow(clippy::cmp_null)]
         if val == $err_state {
             let errno = $crate::error::take_errno();
-            let err = $crate::error::FromErrno::from_errno(errno)
-                .unwrap_or_else(|| panic!("Unknown errno code {errno}"));
+            let err = $crate::error::FromErrno::from_errno(errno);
             return Err(err); // where are we using this in a function that doesn't return result?
         }
         val
@@ -84,7 +102,16 @@ use snafu::Snafu;
 
 pub trait FromErrno {
     /// Consume the current `errno` and, if it contains a known error, returns Self.
-    fn from_errno(num: i32) -> Option<Self>
+    fn try_from_errno(num: i32) -> Option<Self>
+    where
+        Self: Sized;
+    /// The variant to return if the errno value is unknown.
+    fn unknown_variant(num: i32) -> Option<Self>
+    where
+        Self: Sized;
+    /// Consume the current `errno` and returns Self.
+    /// If the error is unknown, returns the result of [`Self::unknown_variant`].
+    fn from_errno(num: i32) -> Self
     where
         Self: Sized;
 }
@@ -95,12 +122,25 @@ pub enum PortError {
     PortOutOfRange,
     #[snafu(display(
         // used to have "Is something else plugged in?" But the vex radio (link) uses the same errno, so that's not always applicable.
-        "The port you specified couldn't be configured as what you specified."
+        "The port you specified couldn't be configured the requested smart device type."
     ))]
     PortCannotBeConfigured,
+    #[snafu(display("{source}"), context(false))]
+    Unknown { source: ErrnoError },
 }
 
 map_errno!(PortError {
     ENXIO => Self::PortOutOfRange,
     ENODEV => Self::PortCannotBeConfigured,
 });
+
+#[derive(Debug, Snafu)]
+#[snafu(display("An unknown error occurred (errno {errno})."))]
+pub struct ErrnoError {
+    pub errno: i32,
+}
+
+map_errno! {
+    ErrnoError {}
+    unknown = |errno| Self { errno };
+}

--- a/packages/pros/src/error.rs
+++ b/packages/pros/src/error.rs
@@ -93,10 +93,7 @@ pub trait FromErrno {
     /// The variant to return if the errno value is unknown.
     fn unknown_variant(num: i32) -> Self
     where
-        Self: Sized,
-    {
-        panic!("Unknown errno code {num}")
-    }
+        Self: Sized;
     /// Consume the current `errno` and returns Self.
     /// If the error is unknown, returns the result of [`Self::unknown_variant`].
     fn from_errno(num: i32) -> Self

--- a/packages/pros/src/link.rs
+++ b/packages/pros/src/link.rs
@@ -129,8 +129,7 @@ impl TxLink {
         match unsafe { link_transmit(self.port, buf.as_ptr().cast(), buf.len() as _) } {
             PROS_ERR_U32 => {
                 let errno = crate::error::take_errno();
-                Err(FromErrno::from_errno(errno)
-                    .unwrap_or_else(|| panic!("Unknown errno code {errno}")))
+                Err(FromErrno::from_errno(errno))
             }
             0 => Err(LinkError::Busy),
             n => Ok(n),

--- a/packages/pros/src/sensors/imu.rs
+++ b/packages/pros/src/sensors/imu.rs
@@ -388,8 +388,7 @@ impl core::future::Future for InertialCalibrateFuture {
                 Self::Calibrate(imu) => match unsafe { pros_sys::imu_reset(imu.port) } {
                     PROS_ERR => {
                         let errno = take_errno();
-                        return Poll::Ready(Err(InertialError::from_errno(errno)
-                            .unwrap_or_else(|| panic!("Unknown errno code {errno}"))));
+                        return Poll::Ready(Err(InertialError::from_errno(errno)));
                     }
                     _ => {
                         *self = Self::Waiting(


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Allows robot code to recover without a panic if it finds an unknown errno value. This is good for reliability and is more future-proof for PROS updates.

## Additional Context
- These changes update the crate's interface (e.g. functions/modules added or changed).
- I have tested these changes on a VEX V5 brain.
<!--
Move all applicable items out of the comment:
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
-->
