### PR TITLE
chore: bump versions and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,27 @@ Before releasing:
 ### Removed
 
 
+## [0.6.0] - 2024-01-14
+
+### Added
+
+### Fixed
+
+- GPS sensor `set_offset` function now returns a result. The relevant PROS C bindings have been fixed as well.
+- FreeRTOS task creation now does not garble data that the provided closure captured.
+- Grammar in the feature request template has been fixed. 
+- Wasm build flags have been updated and fixed.
+
+### Changed
+
+- Panicking behavior has been improved so that spawned tasks will not panic the entire program. 
+- Panic messages are now improved and printed over the serial connection.
+- `AsyncRobot` should now be implemented using the newly stabilized async trait syntax instead of the old `async_trait` attribute macro.
+  
+### Removed
+
+- A nonexistent runner for armv7a-vexos-eabi target has been removed from the cargo config.
+
 ## [0.5.0] - 2024-01-08
 
 ### Added
@@ -64,6 +85,7 @@ Before releasing:
 
 ### Removed
 
-[unreleased]: https://github.com/pros-rs/pros-rs/compare/v0.5.0...HEAD
+[unreleased]: https://github.com/pros-rs/pros-rs/compare/v0.6.0...HEAD
 [0.4.0]: https://github.com/pros-rs/pros-rs/releases/tag/v0.4.0
 [0.5.0]: https://github.com/pros-rs/pros-rs/compare/v0.4.0...v0.5.0
+[0.6.0]: https://github.com/pros-rs/pros-rs/compare/v0.5.0...v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Before releasing:
 
 ### Fixed
 
-- GPS sensor `set_offset` function now returns a result. The relevant PROS C bindings have been fixed as well.
+- GPS sensor `set_offset` function now returns a result. The relevant PROS C bindings have been fixed as well. (**Breaking change**)
 - FreeRTOS task creation now does not garble data that the provided closure captured.
 - Grammar in the feature request template has been fixed. 
 - Wasm build flags have been updated and fixed.
@@ -47,7 +47,7 @@ Before releasing:
 
 - Panicking behavior has been improved so that spawned tasks will not panic the entire program. 
 - Panic messages are now improved and printed over the serial connection.
-- `AsyncRobot` should now be implemented using the newly stabilized async trait syntax instead of the old `async_trait` attribute macro.
+- `AsyncRobot` should now be implemented using the newly stabilized async trait syntax instead of the old `async_trait` attribute macro. (**Breaking change**)
   
 ### Removed
 

--- a/pros-sys/Cargo.toml
+++ b/pros-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pros-sys"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 description = "EFI for the PROS rust bindings"
 keywords = ["PROS", "Robotics", "bindings"]

--- a/pros/Cargo.toml
+++ b/pros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pros"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Rust bindings for PROS"
 keywords = ["PROS", "Robotics", "bindings"]


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Bumps the versions of pros-sys and pros for a new release and updates the changelog.
A new tag (0.6.0) will be created on merge.

## Additional Context
These are *only* non-code changes (e.g. documentation, README.md).
