### PR TITLE
fix(imu): impl From instead of Into

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Before releasing:
 
 ### Added
 
-- New `From` implementation to convert `Quaternion` and `Euler` to their pros-sys equivalents.
+- New `From` implementation to convert `Quaternion` and `Euler` to their pros-sys equivalents. (#45)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,11 @@ Before releasing:
 
 ### Added
 
+- New `From` implementation to convert `Quaternion` and `Euler` to their pros-sys equivalents.
+
 ### Fixed
 
 ### Changed
-
-- Add contributing information, pull request templates, and changelog.
 
 ### Removed
 
@@ -40,15 +40,15 @@ Before releasing:
 
 - GPS sensor `set_offset` function now returns a result. The relevant PROS C bindings have been fixed as well. (**Breaking change**)
 - FreeRTOS task creation now does not garble data that the provided closure captured.
-- Grammar in the feature request template has been fixed. 
+- Grammar in the feature request template has been fixed.
 - Wasm build flags have been updated and fixed.
 
 ### Changed
 
-- Panicking behavior has been improved so that spawned tasks will not panic the entire program. 
+- Panicking behavior has been improved so that spawned tasks will not panic the entire program.
 - Panic messages are now improved and printed over the serial connection.
 - `AsyncRobot` should now be implemented using the newly stabilized async trait syntax instead of the old `async_trait` attribute macro. (**Breaking change**)
-  
+
 ### Removed
 
 - A nonexistent runner for armv7a-vexos-eabi target has been removed from the cargo config.

--- a/pros/src/sensors/imu.rs
+++ b/pros/src/sensors/imu.rs
@@ -278,13 +278,13 @@ impl TryFrom<pros_sys::quaternion_s_t> for Quaternion {
     }
 }
 
-impl Into<pros_sys::quaternion_s_t> for Quaternion {
-    fn into(self) -> pros_sys::quaternion_s_t {
+impl From<Quaternion> for pros_sys::quaternion_s_t {
+    fn from(val: Quaternion) -> Self {
         pros_sys::quaternion_s_t {
-            x: self.x,
-            y: self.y,
-            z: self.z,
-            w: self.w,
+            x: val.x,
+            y: val.y,
+            z: val.z,
+            w: val.w,
         }
     }
 }
@@ -314,12 +314,12 @@ impl TryFrom<pros_sys::euler_s_t> for Euler {
     }
 }
 
-impl Into<pros_sys::euler_s_t> for Euler {
-    fn into(self) -> pros_sys::euler_s_t {
+impl From<Euler> for pros_sys::euler_s_t {
+    fn from(val: Euler) -> Self {
         pros_sys::euler_s_t {
-            pitch: self.pitch,
-            roll: self.roll,
-            yaw: self.yaw,
+            pitch: val.pitch,
+            roll: val.roll,
+            yaw: val.yaw,
         }
     }
 }


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Fixes a clippy warning and adds a `From<Quaternion/Euler> for pros_sys::quaternion/euler_s_t` impl.

## Additional Context
- These changes update the crate's interface (e.g. functions/modules added or changed).
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
-->
