### PR TITLE
fix(competition): remove non-existent pros-sys functions

### DIFF
--- a/pros-sys/src/misc.rs
+++ b/pros-sys/src/misc.rs
@@ -9,12 +9,6 @@ extern "C" {
     /// Get the current status of the competition control.
     /// Returns The competition control status as a mask of bits with COMPETITION_{ENABLED,AUTONOMOUS,CONNECTED}.
     pub fn competition_get_status() -> u8;
-    /// Returns true if the robot is in autonomous mode, false otherwise.
-    pub fn competition_is_autonomous() -> bool;
-    /// Returns true if the V5 Brain is connected to competition control, false otherwise.
-    pub fn competition_is_connected() -> bool;
-    /// Returns true if the V5 Brain is disabled, false otherwise.
-    pub fn competition_is_disabled() -> bool;
 }
 // controller
 pub const E_CONTROLLER_MASTER: c_uint = 0;

--- a/pros/Cargo.toml
+++ b/pros/Cargo.toml
@@ -18,6 +18,7 @@ rust-version = "1.75.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+deprecate-until = "0.1.1"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 spin = "0.9.8"
 pros-sys = { version = "0.4", path = "../pros-sys", features = ["xapi"] }

--- a/pros/src/competition.rs
+++ b/pros/src/competition.rs
@@ -3,6 +3,8 @@
 //! You have the option of getting the entire state ([`get_status`]), or checking a specific one ([`is_autonomous`], etc.).
 //! Once a [`CompetitionStatus`] is created by [`get_status`] it will not be updated again.
 
+use deprecate_until::deprecate_until;
+
 /// The current status of the robot, allowing checks to be made
 /// for autonomous, disabled, and connected states.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -21,21 +23,27 @@ impl CompetitionStatus {
 }
 
 /// Get the current status of the robot.
+#[deprecate_until(remove = ">= 0.7", note = "use `status` instead")]
 pub fn get_status() -> CompetitionStatus {
+    status()
+}
+
+/// Get the current status of the robot.
+pub fn status() -> CompetitionStatus {
     CompetitionStatus(unsafe { pros_sys::misc::competition_get_status() })
 }
 
 /// Check if the robot is in autonomous mode.
 pub fn is_autonomous() -> bool {
-    unsafe { pros_sys::misc::competition_is_autonomous() }
+    status().autonomous()
 }
 
 /// Check if the robot is disabled.
 pub fn is_disabled() -> bool {
-    unsafe { pros_sys::misc::competition_is_disabled() }
+    status().disabled()
 }
 
 /// Check if the robot is connected to a VEX field or competition switch.
 pub fn is_connected() -> bool {
-    unsafe { pros_sys::misc::competition_is_connected() }
+    status().connected()
 }

--- a/pros/src/competition.rs
+++ b/pros/src/competition.rs
@@ -34,16 +34,19 @@ pub fn status() -> CompetitionStatus {
 }
 
 /// Check if the robot is in autonomous mode.
+#[deprecate_until(remove = ">= 0.7", note = "use `status().autonomous()` instead")]
 pub fn is_autonomous() -> bool {
     status().autonomous()
 }
 
 /// Check if the robot is disabled.
+#[deprecate_until(remove = ">= 0.7", note = "use `status().disabled()` instead")]
 pub fn is_disabled() -> bool {
     status().disabled()
 }
 
 /// Check if the robot is connected to a VEX field or competition switch.
+#[deprecate_until(remove = ">= 0.7", note = "use `status().connected()` instead")]
 pub fn is_connected() -> bool {
     status().connected()
 }


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This PR removes bindings to non-existent PROS functions. It also changes the name of `get_status` to comply with the Rust styleguide on getters and deprecates the replaced functions.

## Additional Context
- These changes update the crate's interface (e.g. functions/modules added or changed).
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
-->
