### PR TITLE
refactor: use typed dimensions from `uom`, math types from `mint`

### DIFF
--- a/packages/pros/Cargo.toml
+++ b/packages/pros/Cargo.toml
@@ -31,6 +31,7 @@ slab = { version = "0.4.9", default-features = false }
 hashbrown = { version = "0.14.1", default-features = true }
 async-task = { version = "4.5.0", default-features = false }
 waker-fn = "1.1.1"
+uom = { version = "0.35.0", default-features = false, features = ["si", "autoconvert", "f64"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 dlmalloc = { version = "0.2.4", features = ["global"] }


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This is a draft PR which will update the public interfaces of sensors and devices to use typed quantities where applicable.

## Additional Context

- These changes update the crate's interface (e.g. functions/modules added or changed).
- These are breaking changes (semver: major).

<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are *only* non-code changes (e.g. documentation, README.md).
-->
