### PR TITLE
refactor(breaking): Battery API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Before releasing:
 - Overhauled the `competition` module with more straightforward getters for competition state. (#38) (**Breaking Change**)
 - LLEMU-related macros have been prefixed with `llemu_` (e.g. `llemu_println`). (**Breaking Change**) (#30)
 - Added `Debug`, `Copy`, and `Clone` derives for common structs (#37)
+- Battery API functions now return `Result<_, BatteryError>`. (**Breaking Change**) (#62)
+- Renamed `battery::get_capacity` to `battery::capacity`, `battery::get_current` -> `battery::current`, `battery::get_temperature` -> `battery::temperature`, `battery::get_voltage` -> `battery::voltage`. (**Breaking Change**) (#62)
 
 ### Removed
 

--- a/packages/pros/examples/battery.rs
+++ b/packages/pros/examples/battery.rs
@@ -1,0 +1,21 @@
+#![no_std]
+#![no_main]
+
+use pros::prelude::*;
+use pros::devices::battery;
+
+#[derive(Default)]
+pub struct Robot;
+
+impl AsyncRobot for Robot {
+    async fn opcontrol(&mut self) -> pros::Result {
+		if battery::capacity()? < 20.0 {
+			println!("Battery is low!");
+		} else if battery::temperature()? > 999.0 {
+			println!("Battery has exploded!");
+		}
+
+        Ok(())
+    }
+}
+async_robot!(Robot);

--- a/packages/pros/examples/battery.rs
+++ b/packages/pros/examples/battery.rs
@@ -1,19 +1,18 @@
 #![no_std]
 #![no_main]
 
-use pros::prelude::*;
-use pros::devices::battery;
+use pros::{devices::battery, prelude::*};
 
 #[derive(Default)]
 pub struct Robot;
 
 impl AsyncRobot for Robot {
     async fn opcontrol(&mut self) -> pros::Result {
-		if battery::capacity()? < 20.0 {
-			println!("Battery is low!");
-		} else if battery::temperature()? > 999.0 {
-			println!("Battery has exploded!");
-		}
+        if battery::capacity()? < 20.0 {
+            println!("Battery is low!");
+        } else if battery::temperature()? > 999.0 {
+            println!("Battery has exploded!");
+        }
 
         Ok(())
     }

--- a/packages/pros/src/devices/battery.rs
+++ b/packages/pros/src/devices/battery.rs
@@ -1,21 +1,46 @@
 //! Utilites for getting information about the robot's battery.
 
-/// Get the robot's battery capacity.
-pub fn get_capacity() -> f64 {
-    unsafe { pros_sys::misc::battery_get_capacity() }
-}
+use pros_sys::{PROS_ERR, PROS_ERR_F};
+use snafu::Snafu;
 
-/// Get the electric current of the robot's battery.
-pub fn get_current() -> i32 {
-    unsafe { pros_sys::misc::battery_get_current() }
+use crate::error::{bail_on, map_errno};
+
+/// Get the robot's battery capacity.
+pub fn capacity() -> Result<f64, BatteryError> {
+    Ok(bail_on!(PROS_ERR_F, unsafe {
+        pros_sys::misc::battery_get_capacity()
+    }))
 }
 
 /// Get the current temperature of the robot's battery.
-pub fn get_temperature() -> f64 {
-    unsafe { pros_sys::misc::battery_get_temperature() }
+pub fn temperature() -> Result<f64, BatteryError> {
+    Ok(bail_on!(PROS_ERR_F, unsafe {
+        pros_sys::misc::battery_get_temperature()
+    }))
+}
+
+/// Get the electric current of the robot's battery.
+pub fn current() -> Result<i32, BatteryError> {
+    Ok(bail_on!(PROS_ERR, unsafe {
+        pros_sys::misc::battery_get_current()
+    }))
 }
 
 /// Get the robot's battery voltage.
-pub fn get_voltage() -> i32 {
-    unsafe { pros_sys::misc::battery_get_voltage() }
+pub fn voltage() -> Result<i32, BatteryError> {
+    Ok(bail_on!(PROS_ERR, unsafe {
+        pros_sys::misc::battery_get_voltage()
+    }))
+}
+
+#[derive(Debug, Snafu)]
+pub enum BatteryError {
+    #[snafu(display("Another resource is already using the controller"))]
+    ConcurrentAccess,
+}
+
+map_errno! {
+    BatteryError {
+        EACCES => Self::ConcurrentAccess,
+    }
 }

--- a/packages/pros/src/devices/battery.rs
+++ b/packages/pros/src/devices/battery.rs
@@ -35,7 +35,7 @@ pub fn voltage() -> Result<i32, BatteryError> {
 
 #[derive(Debug, Snafu)]
 pub enum BatteryError {
-    #[snafu(display("Another resource is already using the controller"))]
+    #[snafu(display("Another resource is already using the battery"))]
     ConcurrentAccess,
 }
 


### PR DESCRIPTION
Closes #50 
## Describe the changes this PR makes. Why should it be merged?
- Fixes battery getters to actually handle errors.
- Renames battery getters to correct naming scheme (removes `get_`).

## Additional Context
Breaking change (semver:major).