### PR TITLE
fix: resolve wasm build errors

### DIFF
--- a/packages/pros-sys/src/lib.rs
+++ b/packages/pros-sys/src/lib.rs
@@ -22,7 +22,7 @@ pub mod rotation;
 pub mod rtos;
 pub mod vision;
 
-use core::ffi::c_char;
+use core::ffi::{c_char, c_int, c_void};
 
 pub use adi::*;
 pub use colors::*;
@@ -48,11 +48,12 @@ pub const CLOCKS_PER_SEC: u32 = 1000;
 
 extern "C" {
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn memalign(alignment: usize, size: usize) -> *mut core::ffi::c_void;
+    pub fn memalign(alignment: usize, size: usize) -> *mut c_void;
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn free(ptr: *mut core::ffi::c_void);
+    pub fn free(ptr: *mut c_void);
     pub fn __errno() -> *mut i32;
     pub fn clock() -> i32;
     pub fn puts(s: *const c_char) -> i32;
     pub fn exit(code: i32) -> !;
+    pub fn write(fd: c_int, buf: *const c_void, count: usize) -> isize;
 }

--- a/packages/pros/Cargo.toml
+++ b/packages/pros/Cargo.toml
@@ -31,7 +31,6 @@ slab = { version = "0.4.9", default-features = false }
 hashbrown = { version = "0.14.1", default-features = true }
 async-task = { version = "4.5.0", default-features = false }
 waker-fn = "1.1.1"
-libc-print = "0.1.22"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 dlmalloc = { version = "0.2.4", features = ["global"] }

--- a/packages/pros/src/io/mod.rs
+++ b/packages/pros/src/io/mod.rs
@@ -1,4 +1,5 @@
 //! Helpers for terminal I/O functionality.
 
-pub use libc_print::std_name::*;
+pub mod print_impl;
+
 pub use no_std_io::io::*;

--- a/packages/pros/src/io/print_impl.rs
+++ b/packages/pros/src/io/print_impl.rs
@@ -65,19 +65,19 @@
 use core::{convert::TryFrom, file, line, stringify};
 
 #[doc(hidden)]
-pub struct __ProsSysWriter(i32);
+pub struct __SerialWriter(i32);
 
-impl core::fmt::Write for __ProsSysWriter {
+impl core::fmt::Write for __SerialWriter {
     #[inline]
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         __println(self.0, s)
     }
 }
 
-impl __ProsSysWriter {
+impl __SerialWriter {
     #[inline]
-    pub const fn new(err: bool) -> __ProsSysWriter {
-        __ProsSysWriter(if err { 2 } else { 1 })
+    pub const fn new(err: bool) -> __SerialWriter {
+        __SerialWriter(if err { 2 } else { 1 })
     }
 
     #[inline]
@@ -137,7 +137,7 @@ macro_rules! println {
         {
             #[allow(unused_must_use)]
             {
-                let mut stm = $crate::io::print_impl::__ProsSysWriter::new(false);
+                let mut stm = $crate::io::print_impl::__SerialWriter::new(false);
                 stm.write_fmt(format_args!($($arg)*));
                 stm.write_nl();
             }
@@ -157,7 +157,7 @@ macro_rules! print {
         {
             #[allow(unused_must_use)]
             {
-                let mut stm = $crate::io::print_impl::__ProsSysWriter::new(false);
+                let mut stm = $crate::io::print_impl::__SerialWriter::new(false);
                 stm.write_fmt(format_args!($($arg)*));
             }
         }
@@ -177,7 +177,7 @@ macro_rules! eprintln {
         {
             #[allow(unused_must_use)]
             {
-                let mut stm = $crate::io::print_impl::__ProsSysWriter::new(true);
+                let mut stm = $crate::io::print_impl::__SerialWriter::new(true);
                 stm.write_fmt(format_args!($($arg)*));
                 stm.write_nl();
             }
@@ -197,7 +197,7 @@ macro_rules! eprint {
         {
             #[allow(unused_must_use)]
             {
-                let mut stm = $crate::io::print_impl::__ProsSysWriter::new(true);
+                let mut stm = $crate::io::print_impl::__SerialWriter::new(true);
                 stm.write_fmt(format_args!($($arg)*));
             }
         }
@@ -212,7 +212,7 @@ macro_rules! write {
     ($arg:expr) => {
         #[allow(unused_must_use)]
         {
-            let mut stm = $crate::io::print_impl::__ProsSysWriter::new(false);
+            let mut stm = $crate::io::print_impl::__SerialWriter::new(false);
             stm.write_str($arg);
         }
     };
@@ -226,7 +226,7 @@ macro_rules! ewrite {
     ($arg:expr) => {{
         #[allow(unused_must_use)]
         {
-            let mut stm = $crate::io::print_impl::__ProsSysWriter::new(true);
+            let mut stm = $crate::io::print_impl::__SerialWriter::new(true);
             stm.write_str($arg);
         }
     }};
@@ -240,7 +240,7 @@ macro_rules! writeln {
     ($arg:expr) => {
         #[allow(unused_must_use)]
         {
-            let mut stm = $crate::io::print_impl::__ProsSysWriter::new(false);
+            let mut stm = $crate::io::print_impl::__SerialWriter::new(false);
             stm.write_str($arg);
             stm.write_nl();
         }
@@ -255,7 +255,7 @@ macro_rules! ewriteln {
     ($arg:expr) => {{
         #[allow(unused_must_use)]
         {
-            let mut stm = $crate::io::print_impl::__ProsSysWriter::new(true);
+            let mut stm = $crate::io::print_impl::__SerialWriter::new(true);
             stm.write_str($arg);
             stm.write_nl();
         }

--- a/packages/pros/src/io/print_impl.rs
+++ b/packages/pros/src/io/print_impl.rs
@@ -61,16 +61,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#[allow(unused_imports)]
 use core::{convert::TryFrom, file, line, stringify};
-
-// These constants are used by the macros but we don't want to expose
-// them to library users.
-#[doc(hidden)]
-pub const __NEWLINE: &str = "\n";
-#[doc(hidden)]
-pub const __STDOUT: i32 = 1;
-#[doc(hidden)]
-pub const __STDERR: i32 = 2;
 
 #[doc(hidden)]
 pub struct __ProsSysWriter(i32);
@@ -84,8 +76,8 @@ impl core::fmt::Write for __ProsSysWriter {
 
 impl __ProsSysWriter {
     #[inline]
-    pub fn new(handle: i32) -> __ProsSysWriter {
-        __ProsSysWriter(handle)
+    pub const fn new(err: bool) -> __ProsSysWriter {
+        __ProsSysWriter(if err { 2 } else { 1 })
     }
 
     #[inline]
@@ -100,7 +92,7 @@ impl __ProsSysWriter {
 
     #[inline]
     pub fn write_nl(&mut self) -> core::fmt::Result {
-        __println(self.0, __NEWLINE)
+        __println(self.0, "\n")
     }
 }
 
@@ -145,7 +137,7 @@ macro_rules! println {
         {
             #[allow(unused_must_use)]
             {
-                let mut stm = $crate::io::print_impl::__ProsSysWriter::new($crate::io::print_impl::__STDOUT);
+                let mut stm = $crate::io::print_impl::__ProsSysWriter::new(false);
                 stm.write_fmt(format_args!($($arg)*));
                 stm.write_nl();
             }
@@ -165,7 +157,7 @@ macro_rules! print {
         {
             #[allow(unused_must_use)]
             {
-                let mut stm = $crate::io::print_impl::__ProsSysWriter::new($crate::io::print_impl::__STDOUT);
+                let mut stm = $crate::io::print_impl::__ProsSysWriter::new(false);
                 stm.write_fmt(format_args!($($arg)*));
             }
         }
@@ -185,7 +177,7 @@ macro_rules! eprintln {
         {
             #[allow(unused_must_use)]
             {
-                let mut stm = $crate::io::print_impl::__ProsSysWriter::new($crate::io::print_impl::__STDERR);
+                let mut stm = $crate::io::print_impl::__ProsSysWriter::new(true);
                 stm.write_fmt(format_args!($($arg)*));
                 stm.write_nl();
             }
@@ -205,7 +197,7 @@ macro_rules! eprint {
         {
             #[allow(unused_must_use)]
             {
-                let mut stm = $crate::io::print_impl::__ProsSysWriter::new($crate::io::print_impl::__STDERR);
+                let mut stm = $crate::io::print_impl::__ProsSysWriter::new(true);
                 stm.write_fmt(format_args!($($arg)*));
             }
         }
@@ -220,8 +212,7 @@ macro_rules! write {
     ($arg:expr) => {
         #[allow(unused_must_use)]
         {
-            let mut stm =
-                $crate::io::print_impl::__ProsSysWriter::new($crate::io::print_impl::__STDOUT);
+            let mut stm = $crate::io::print_impl::__ProsSysWriter::new(false);
             stm.write_str($arg);
         }
     };
@@ -235,8 +226,7 @@ macro_rules! ewrite {
     ($arg:expr) => {{
         #[allow(unused_must_use)]
         {
-            let mut stm =
-                $crate::io::print_impl::__ProsSysWriter::new($crate::io::print_impl::__STDERR);
+            let mut stm = $crate::io::print_impl::__ProsSysWriter::new(true);
             stm.write_str($arg);
         }
     }};
@@ -250,8 +240,7 @@ macro_rules! writeln {
     ($arg:expr) => {
         #[allow(unused_must_use)]
         {
-            let mut stm =
-                $crate::io::print_impl::__ProsSysWriter::new($crate::io::print_impl::__STDOUT);
+            let mut stm = $crate::io::print_impl::__ProsSysWriter::new(false);
             stm.write_str($arg);
             stm.write_nl();
         }
@@ -266,8 +255,7 @@ macro_rules! ewriteln {
     ($arg:expr) => {{
         #[allow(unused_must_use)]
         {
-            let mut stm =
-                $crate::io::print_impl::__ProsSysWriter::new($crate::io::print_impl::__STDERR);
+            let mut stm = $crate::io::print_impl::__ProsSysWriter::new(true);
             stm.write_str($arg);
             stm.write_nl();
         }

--- a/packages/pros/src/io/print_impl.rs
+++ b/packages/pros/src/io/print_impl.rs
@@ -61,19 +61,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#![no_std]
-#![allow(dead_code)]
-#![allow(unused)]
-#![warn(unsafe_op_in_unsafe_fn)]
-
 use core::{convert::TryFrom, file, line, stringify};
-
-/// This forces a "C" library linkage
-#[cfg(not(windows))]
-#[link(name = "c")]
-mod c {
-    extern "C" {}
-}
 
 // These constants are used by the macros but we don't want to expose
 // them to library users.

--- a/packages/pros/src/io/print_impl.rs
+++ b/packages/pros/src/io/print_impl.rs
@@ -1,0 +1,318 @@
+//! Implements `println!`, `eprintln!` and `dbg!` on top of the `pros_sys` crate without requiring
+//! the use of an allocator. (Modified version of `libc_print` crate)
+//!
+//! Allows you to use these macros in a #!\[no_std\] context, or in a situation where the
+//! traditional Rust streams might not be available (ie: at process shutdown time).
+//!
+//! [`writeln`] and [`ewriteln`] are provided for cases where you may not wish
+//! to pull in the overhead of the formatter code and simply wish to print C-style strings.
+//!
+//! ## Usage
+//!
+//! Exactly as you'd use `println!`, `eprintln!` and `dbg!`.
+//!
+//! ```rust
+//! # use pros::io::print_impl::*;
+//! // Use the default ``-prefixed macros:
+//! # fn test1()
+//! # {
+//! println!("Hello {}!", "stdout");
+//! eprintln!("Hello {}!", "stderr");
+//! let a = 2;
+//! let b = dbg!(a * 2) + 1;
+//! assert_eq!(b, 5);
+//! # }
+//! ```
+//!
+//! Or you can import aliases to `std` names:
+//!
+//! ```rust
+//! use pros::io::print_impl::{println, eprintln, dbg};
+//!
+//! # fn test2()
+//! # {
+//! println!("Hello {}!", "stdout");
+//! eprintln!("Hello {}!", "stderr");
+//! let a = 2;
+//! let b = dbg!(a * 2) + 1;
+//! assert_eq!(b, 5);
+//! # }
+//! ```
+
+// libc_print is licensed under the MIT License:
+
+// Copyright (c) 2023 Matt Mastracci and contributors
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#![no_std]
+#![allow(dead_code)]
+#![allow(unused)]
+#![warn(unsafe_op_in_unsafe_fn)]
+
+use core::{convert::TryFrom, file, line, stringify};
+
+/// This forces a "C" library linkage
+#[cfg(not(windows))]
+#[link(name = "c")]
+mod c {
+    extern "C" {}
+}
+
+// These constants are used by the macros but we don't want to expose
+// them to library users.
+#[doc(hidden)]
+pub const __NEWLINE: &str = "\n";
+#[doc(hidden)]
+pub const __STDOUT: i32 = 1;
+#[doc(hidden)]
+pub const __STDERR: i32 = 2;
+
+#[doc(hidden)]
+pub struct __ProsSysWriter(i32);
+
+impl core::fmt::Write for __ProsSysWriter {
+    #[inline]
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        __println(self.0, s)
+    }
+}
+
+impl __ProsSysWriter {
+    #[inline]
+    pub fn new(handle: i32) -> __ProsSysWriter {
+        __ProsSysWriter(handle)
+    }
+
+    #[inline]
+    pub fn write_fmt(&mut self, args: core::fmt::Arguments) -> core::fmt::Result {
+        core::fmt::Write::write_fmt(self, args)
+    }
+
+    #[inline]
+    pub fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        __println(self.0, s)
+    }
+
+    #[inline]
+    pub fn write_nl(&mut self) -> core::fmt::Result {
+        __println(self.0, __NEWLINE)
+    }
+}
+
+#[doc(hidden)]
+#[inline]
+pub fn __println(handle: i32, msg: &str) -> core::fmt::Result {
+    let msg = msg.as_bytes();
+
+    let mut written = 0;
+    while written < msg.len() {
+        match unsafe { write(handle, &msg[written..]) } {
+            // Ignore errors
+            None | Some(0) => break,
+            Some(res) => written += res,
+        }
+    }
+
+    Ok(())
+}
+
+unsafe fn write(handle: i32, bytes: &[u8]) -> Option<usize> {
+    usize::try_from(unsafe {
+        pros_sys::write(
+            handle,
+            bytes.as_ptr().cast::<core::ffi::c_void>(),
+            bytes.len(),
+        )
+    })
+    .ok()
+}
+
+/// Macro for printing to the standard output, with a newline.
+///
+/// Does not panic on failure to write - instead silently ignores errors.
+///
+/// See [`println!`](https://doc.rust-lang.org/std/macro.println.html) for
+/// full documentation.
+#[macro_export]
+macro_rules! println {
+    () => { $crate::println!("") };
+    ($($arg:tt)*) => {
+        {
+            #[allow(unused_must_use)]
+            {
+                let mut stm = $crate::io::print_impl::__ProsSysWriter::new($crate::io::print_impl::__STDOUT);
+                stm.write_fmt(format_args!($($arg)*));
+                stm.write_nl();
+            }
+        }
+    };
+}
+
+/// Macro for printing to the standard output.
+///
+/// Does not panic on failure to write - instead silently ignores errors.
+///
+/// See [`print!`](https://doc.rust-lang.org/std/macro.print.html) for
+/// full documentation.
+#[macro_export]
+macro_rules! print {
+    ($($arg:tt)*) => {
+        {
+            #[allow(unused_must_use)]
+            {
+                let mut stm = $crate::io::print_impl::__ProsSysWriter::new($crate::io::print_impl::__STDOUT);
+                stm.write_fmt(format_args!($($arg)*));
+            }
+        }
+    };
+}
+
+/// Macro for printing to the standard error, with a newline.
+///
+/// Does not panic on failure to write - instead silently ignores errors.
+///
+/// See [`eprintln!`](https://doc.rust-lang.org/std/macro.eprintln.html) for
+/// full documentation.
+#[macro_export]
+macro_rules! eprintln {
+    () => { $crate::eprintln!("") };
+    ($($arg:tt)*) => {
+        {
+            #[allow(unused_must_use)]
+            {
+                let mut stm = $crate::io::print_impl::__ProsSysWriter::new($crate::io::print_impl::__STDERR);
+                stm.write_fmt(format_args!($($arg)*));
+                stm.write_nl();
+            }
+        }
+    };
+}
+
+/// Macro for printing to the standard error.
+///
+/// Does not panic on failure to write - instead silently ignores errors.
+///
+/// See [`eprint!`](https://doc.rust-lang.org/std/macro.eprint.html) for
+/// full documentation.
+#[macro_export]
+macro_rules! eprint {
+    ($($arg:tt)*) => {
+        {
+            #[allow(unused_must_use)]
+            {
+                let mut stm = $crate::io::print_impl::__ProsSysWriter::new($crate::io::print_impl::__STDERR);
+                stm.write_fmt(format_args!($($arg)*));
+            }
+        }
+    };
+}
+
+/// Macro for printing a static string to the standard output.
+///
+/// Does not panic on failure to write - instead silently ignores errors.
+#[macro_export]
+macro_rules! write {
+    ($arg:expr) => {
+        #[allow(unused_must_use)]
+        {
+            let mut stm =
+                $crate::io::print_impl::__ProsSysWriter::new($crate::io::print_impl::__STDOUT);
+            stm.write_str($arg);
+        }
+    };
+}
+
+/// Macro for printing a static string to the standard error.
+///
+/// Does not panic on failure to write - instead silently ignores errors.
+#[macro_export]
+macro_rules! ewrite {
+    ($arg:expr) => {{
+        #[allow(unused_must_use)]
+        {
+            let mut stm =
+                $crate::io::print_impl::__ProsSysWriter::new($crate::io::print_impl::__STDERR);
+            stm.write_str($arg);
+        }
+    }};
+}
+
+/// Macro for printing a static string to the standard output, with a newline.
+///
+/// Does not panic on failure to write - instead silently ignores errors.
+#[macro_export]
+macro_rules! writeln {
+    ($arg:expr) => {
+        #[allow(unused_must_use)]
+        {
+            let mut stm =
+                $crate::io::print_impl::__ProsSysWriter::new($crate::io::print_impl::__STDOUT);
+            stm.write_str($arg);
+            stm.write_nl();
+        }
+    };
+}
+
+/// Macro for printing a static string to the standard error, with a newline.
+///
+/// Does not panic on failure to write - instead silently ignores errors.
+#[macro_export]
+macro_rules! ewriteln {
+    ($arg:expr) => {{
+        #[allow(unused_must_use)]
+        {
+            let mut stm =
+                $crate::io::print_impl::__ProsSysWriter::new($crate::io::print_impl::__STDERR);
+            stm.write_str($arg);
+            stm.write_nl();
+        }
+    }};
+}
+
+/// Prints and returns the value of a given expression for quick and dirty
+/// debugging.
+///
+/// An example:
+///
+/// ```rust
+/// let a = 2;
+/// let b = dbg!(a * 2) + 1;
+/// //      ^-- prints: [src/main.rs:2] a * 2 = 4
+/// assert_eq!(b, 5);
+/// ```
+///
+/// See [dbg!](https://doc.rust-lang.org/std/macro.dbg.html) for full documentation.
+#[macro_export]
+macro_rules! dbg {
+    () => {
+        $crate::eprintln!("[{}:{}]", $file!(), $line!())
+    };
+    ($val:expr $(,)?) => {
+        match $val {
+            tmp => {
+                $crate::eprintln!("[{}:{}] {} = {:#?}", file!(), line!(), stringify!($val), &tmp);
+                tmp
+            }
+        }
+    };
+    ($($val:expr),+ $(,)?) => {
+        ($($crate::dbg!($val)),+,)
+    };
+}

--- a/packages/pros/src/lib.rs
+++ b/packages/pros/src/lib.rs
@@ -83,8 +83,6 @@ pub mod usd;
 
 pub type Result<T = ()> = core::result::Result<T, alloc::boxed::Box<dyn core::error::Error>>;
 
-use crate::io::println;
-
 pub trait AsyncRobot {
     fn opcontrol(&mut self) -> impl Future<Output = Result> {
         async { Ok(()) }
@@ -357,10 +355,9 @@ pub fn panic(info: &core::panic::PanicInfo) -> ! {
     // panic message here
     println!("task '{task_name}' {info}");
 
-    #[cfg(target_arch = "wasm32")]
-    wasm_env::sim_log_backtrace();
-
     unsafe {
+        #[cfg(target_arch = "wasm32")]
+        wasm_env::sim_log_backtrace();
         pros_sys::exit(1);
     }
 }
@@ -374,6 +371,7 @@ pub mod prelude {
     pub use crate::{
         async_robot,
         async_runtime::*,
+        dbg,
         devices::{
             adi::{
                 analog::{AdiAnalogIn, AdiAnalogOut},
@@ -398,12 +396,13 @@ pub mod prelude {
                 SmartDevice, SmartPort,
             },
         },
+        eprint, eprintln,
         error::PortError,
-        io::{dbg, eprint, eprintln, print, println, BufRead, Read, Seek, Write},
+        io::{BufRead, Read, Seek, Write},
         lcd::{buttons::Button, llemu_print, llemu_println, LcdError},
         os_task_local,
         pid::*,
-        sync_robot,
+        print, println, sync_robot,
         task::{delay, sleep, spawn},
         AsyncRobot, SyncRobot,
     };


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Fixes WASM build errors by using a custom version of libc_print and moving an unsafe function into an unsafe block.

## Additional Context
- These are breaking changes (semver: major).
- These changes update the crate's interface (e.g. functions/modules added or changed).
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
<!--
Move all applicable items out of the comment:
- These are *only* non-code changes (e.g. documentation, README.md).
-->
