### PR TITLE
fix: Handle controller status errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Before releasing:
 - Fixed errors in doctests and examples throughout the crate. (#37)
 - Fixed Missing ERRNO and ADI config variants in pros-sys (#55)
 - Fixed incorrect error handling with `InertialSensor::status`. (#65)
+- `Controller::status` now handles errors by returning `Result<ControllerStatus, ControllerError>`. (**Breaking Change**) (#74)
 
 ### Changed
 

--- a/packages/pros/src/devices/controller.rs
+++ b/packages/pros/src/devices/controller.rs
@@ -135,31 +135,43 @@ impl Controller {
     }
 
     /// Gets the current state of the controller in its entirety.
-    pub fn state(&self) -> ControllerState {
-        ControllerState {
+    pub fn state(&self) -> Result<ControllerState, ControllerError> {
+        Ok(ControllerState {
             joysticks: unsafe {
                 Joysticks {
                     left: Joystick {
-                        x: pros_sys::controller_get_analog(
-                            self.id(),
-                            pros_sys::E_CONTROLLER_ANALOG_LEFT_X,
+                        x: bail_on!(
+                            PROS_ERR,
+                            pros_sys::controller_get_analog(
+                                self.id(),
+                                pros_sys::E_CONTROLLER_ANALOG_LEFT_X,
+                            )
                         ) as f32
                             / 127.0,
-                        y: pros_sys::controller_get_analog(
-                            self.id(),
-                            pros_sys::E_CONTROLLER_ANALOG_LEFT_Y,
+                        y: bail_on!(
+                            PROS_ERR,
+                            pros_sys::controller_get_analog(
+                                self.id(),
+                                pros_sys::E_CONTROLLER_ANALOG_LEFT_Y,
+                            )
                         ) as f32
                             / 127.0,
                     },
                     right: Joystick {
-                        x: pros_sys::controller_get_analog(
-                            self.id(),
-                            pros_sys::E_CONTROLLER_ANALOG_RIGHT_X,
+                        x: bail_on!(
+                            PROS_ERR,
+                            pros_sys::controller_get_analog(
+                                self.id(),
+                                pros_sys::E_CONTROLLER_ANALOG_RIGHT_X,
+                            )
                         ) as f32
                             / 127.0,
-                        y: pros_sys::controller_get_analog(
-                            self.id(),
-                            pros_sys::E_CONTROLLER_ANALOG_RIGHT_Y,
+                        y: bail_on!(
+                            PROS_ERR,
+                            pros_sys::controller_get_analog(
+                                self.id(),
+                                pros_sys::E_CONTROLLER_ANALOG_RIGHT_Y,
+                            )
                         ) as f32
                             / 127.0,
                     },
@@ -167,72 +179,117 @@ impl Controller {
             },
             buttons: unsafe {
                 Buttons {
-                    a: pros_sys::controller_get_digital(
-                        self.id(),
-                        pros_sys::E_CONTROLLER_DIGITAL_A,
+                    a: bail_on!(
+                        PROS_ERR,
+                        pros_sys::controller_get_digital(
+                            self.id(),
+                            pros_sys::E_CONTROLLER_DIGITAL_A,
+                        )
                     ) == 1,
-                    b: pros_sys::controller_get_digital(
-                        self.id(),
-                        pros_sys::E_CONTROLLER_DIGITAL_B,
+                    b: bail_on!(
+                        PROS_ERR,
+                        pros_sys::controller_get_digital(
+                            self.id(),
+                            pros_sys::E_CONTROLLER_DIGITAL_B,
+                        )
                     ) == 1,
-                    x: pros_sys::controller_get_digital(
-                        self.id(),
-                        pros_sys::E_CONTROLLER_DIGITAL_X,
+                    x: bail_on!(
+                        PROS_ERR,
+                        pros_sys::controller_get_digital(
+                            self.id(),
+                            pros_sys::E_CONTROLLER_DIGITAL_X,
+                        )
                     ) == 1,
-                    y: pros_sys::controller_get_digital(
-                        self.id(),
-                        pros_sys::E_CONTROLLER_DIGITAL_Y,
+                    y: bail_on!(
+                        PROS_ERR,
+                        pros_sys::controller_get_digital(
+                            self.id(),
+                            pros_sys::E_CONTROLLER_DIGITAL_Y,
+                        )
                     ) == 1,
-                    up: pros_sys::controller_get_digital(
-                        self.id(),
-                        pros_sys::E_CONTROLLER_DIGITAL_UP,
+                    up: bail_on!(
+                        PROS_ERR,
+                        pros_sys::controller_get_digital(
+                            self.id(),
+                            pros_sys::E_CONTROLLER_DIGITAL_UP,
+                        )
                     ) == 1,
-                    down: pros_sys::controller_get_digital(
-                        self.id(),
-                        pros_sys::E_CONTROLLER_DIGITAL_DOWN,
+                    down: bail_on!(
+                        PROS_ERR,
+                        pros_sys::controller_get_digital(
+                            self.id(),
+                            pros_sys::E_CONTROLLER_DIGITAL_DOWN,
+                        )
                     ) == 1,
-                    left: pros_sys::controller_get_digital(
-                        self.id(),
-                        pros_sys::E_CONTROLLER_DIGITAL_LEFT,
+                    left: bail_on!(
+                        PROS_ERR,
+                        pros_sys::controller_get_digital(
+                            self.id(),
+                            pros_sys::E_CONTROLLER_DIGITAL_LEFT,
+                        )
                     ) == 1,
-                    right: pros_sys::controller_get_digital(
-                        self.id(),
-                        pros_sys::E_CONTROLLER_DIGITAL_RIGHT,
+                    right: bail_on!(
+                        PROS_ERR,
+                        pros_sys::controller_get_digital(
+                            self.id(),
+                            pros_sys::E_CONTROLLER_DIGITAL_RIGHT,
+                        )
                     ) == 1,
-                    left_trigger_1: pros_sys::controller_get_digital(
-                        self.id(),
-                        pros_sys::E_CONTROLLER_DIGITAL_L1,
+                    left_trigger_1: bail_on!(
+                        PROS_ERR,
+                        pros_sys::controller_get_digital(
+                            self.id(),
+                            pros_sys::E_CONTROLLER_DIGITAL_L1,
+                        )
                     ) == 1,
-                    left_trigger_2: pros_sys::controller_get_digital(
-                        self.id(),
-                        pros_sys::E_CONTROLLER_DIGITAL_L2,
+                    left_trigger_2: bail_on!(
+                        PROS_ERR,
+                        pros_sys::controller_get_digital(
+                            self.id(),
+                            pros_sys::E_CONTROLLER_DIGITAL_L2,
+                        )
                     ) == 1,
-                    right_trigger_1: pros_sys::controller_get_digital(
-                        self.id(),
-                        pros_sys::E_CONTROLLER_DIGITAL_R1,
+                    right_trigger_1: bail_on!(
+                        PROS_ERR,
+                        pros_sys::controller_get_digital(
+                            self.id(),
+                            pros_sys::E_CONTROLLER_DIGITAL_R1,
+                        )
                     ) == 1,
-                    right_trigger_2: pros_sys::controller_get_digital(
-                        self.id(),
-                        pros_sys::E_CONTROLLER_DIGITAL_R2,
+                    right_trigger_2: bail_on!(
+                        PROS_ERR,
+                        pros_sys::controller_get_digital(
+                            self.id(),
+                            pros_sys::E_CONTROLLER_DIGITAL_R2,
+                        )
                     ) == 1,
                 }
             },
-        }
+        })
     }
 
     /// Gets the state of a specific button on the controller.
-    pub fn button(&self, button: ControllerButton) -> bool {
-        unsafe { pros_sys::controller_get_digital(self.id(), button as u32) == 1 }
+    pub fn button(&self, button: ControllerButton) -> Result<bool, ControllerError> {
+        Ok(bail_on!(PROS_ERR, unsafe {
+            pros_sys::controller_get_digital(self.id(), button as pros_sys::controller_digital_e_t)
+        }) == 1)
     }
 
     /// Gets the state of a specific joystick axis on the controller.
-    pub fn joystick_axis(&self, axis: JoystickAxis) -> f32 {
-        unsafe { pros_sys::controller_get_analog(self.id(), axis as u32) as f32 / 127.0 }
+    pub fn joystick_axis(&self, axis: JoystickAxis) -> Result<f32, ControllerError> {
+        Ok(bail_on!(PROS_ERR, unsafe {
+            pros_sys::controller_get_analog(self.id(), axis as pros_sys::controller_analog_e_t)
+        }) as f32 / 127.0)
     }
 }
 
 #[derive(Debug, Snafu)]
 pub enum ControllerError {
+    #[snafu(display(
+        "A controller ID other than E_CONTROLLER_MASTER or E_CONTROLLER_PARTNER was given."
+    ))]
+    InvalidControllerId,
+
     #[snafu(display("Another resource is already using the controller"))]
     ConcurrentAccess,
 }
@@ -240,5 +297,6 @@ pub enum ControllerError {
 map_errno! {
     ControllerError {
         EACCES => Self::ConcurrentAccess,
+        EINVAL => Self::InvalidControllerId,
     }
 }

--- a/packages/pros/src/devices/controller.rs
+++ b/packages/pros/src/devices/controller.rs
@@ -279,7 +279,8 @@ impl Controller {
     pub fn joystick_axis(&self, axis: JoystickAxis) -> Result<f32, ControllerError> {
         Ok(bail_on!(PROS_ERR, unsafe {
             pros_sys::controller_get_analog(self.id(), axis as pros_sys::controller_analog_e_t)
-        }) as f32 / 127.0)
+        }) as f32
+            / 127.0)
     }
 }
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Makes `Controller::status()` return `ControllerError` if one or more of the getter functions it calls fail.

## Additional Context
- Untested on actual hardware, but should be better than before either way.
- Closes #71
- This is a breaking change (semver:major).