### PR TITLE
fix: ADI error handling

### DIFF
--- a/packages/pros/src/devices/adi/potentiometer.rs
+++ b/packages/pros/src/devices/adi/potentiometer.rs
@@ -1,4 +1,4 @@
-use pros_sys::{adi_potentiometer_type_e_t, ext_adi_potentiometer_t, PROS_ERR};
+use pros_sys::{adi_potentiometer_type_e_t, ext_adi_potentiometer_t, PROS_ERR, PROS_ERR_F};
 
 use super::{AdiDevice, AdiDeviceType, AdiError, AdiPort};
 use crate::error::bail_on;
@@ -39,7 +39,7 @@ impl AdiPotentiometer {
     /// Potentiometer V2 rotates 330 degrees
     /// thus returning an angle between 0-330 degrees.
     pub fn angle(&self) -> Result<f64, AdiError> {
-        Ok(bail_on!(PROS_ERR.into(), unsafe {
+        Ok(bail_on!(PROS_ERR_F, unsafe {
             pros_sys::ext_adi_potentiometer_get_angle(self.raw)
         }))
     }


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Fixes various ADI error handling mishaps, such as checking for the wrong error return and clarifying some returned errno codes.