### PR TITLE
refactor(breaking): remove nonstandard printing macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,11 @@ Before releasing:
 
 ### Changed
 
+- Re-exported printing macros from `pros::io`. (#82)
+
 ### Removed
+
+- Removed the confusingly named `write`, `ewrite`, `writeln`, and `ewriteln` macros. (**Breaking Change**) (#82)
 
 ## [0.7.0]
 

--- a/packages/pros/src/io/mod.rs
+++ b/packages/pros/src/io/mod.rs
@@ -3,3 +3,5 @@
 pub mod print_impl;
 
 pub use no_std_io::io::*;
+
+pub use crate::{dbg, eprint, eprintln, print, println};

--- a/packages/pros/src/io/print_impl.rs
+++ b/packages/pros/src/io/print_impl.rs
@@ -4,9 +4,6 @@
 //! Allows you to use these macros in a #!\[no_std\] context, or in a situation where the
 //! traditional Rust streams might not be available (ie: at process shutdown time).
 //!
-//! [`writeln`] and [`ewriteln`] are provided for cases where you may not wish
-//! to pull in the overhead of the formatter code and simply wish to print C-style strings.
-//!
 //! ## Usage
 //!
 //! Exactly as you'd use `println!`, `eprintln!` and `dbg!`.

--- a/packages/pros/src/io/print_impl.rs
+++ b/packages/pros/src/io/print_impl.rs
@@ -204,36 +204,6 @@ macro_rules! eprint {
     };
 }
 
-/// Macro for printing a static string to the standard output, with a newline.
-///
-/// Does not panic on failure to write - instead silently ignores errors.
-#[macro_export]
-macro_rules! writeln {
-    ($arg:expr) => {
-        #[allow(unused_must_use)]
-        {
-            let mut stm = $crate::io::print_impl::__SerialWriter::new(false);
-            stm.write_str($arg);
-            stm.write_nl();
-        }
-    };
-}
-
-/// Macro for printing a static string to the standard error, with a newline.
-///
-/// Does not panic on failure to write - instead silently ignores errors.
-#[macro_export]
-macro_rules! ewriteln {
-    ($arg:expr) => {{
-        #[allow(unused_must_use)]
-        {
-            let mut stm = $crate::io::print_impl::__SerialWriter::new(true);
-            stm.write_str($arg);
-            stm.write_nl();
-        }
-    }};
-}
-
 /// Prints and returns the value of a given expression for quick and dirty
 /// debugging.
 ///

--- a/packages/pros/src/io/print_impl.rs
+++ b/packages/pros/src/io/print_impl.rs
@@ -204,34 +204,6 @@ macro_rules! eprint {
     };
 }
 
-/// Macro for printing a static string to the standard output.
-///
-/// Does not panic on failure to write - instead silently ignores errors.
-#[macro_export]
-macro_rules! write {
-    ($arg:expr) => {
-        #[allow(unused_must_use)]
-        {
-            let mut stm = $crate::io::print_impl::__SerialWriter::new(false);
-            stm.write_str($arg);
-        }
-    };
-}
-
-/// Macro for printing a static string to the standard error.
-///
-/// Does not panic on failure to write - instead silently ignores errors.
-#[macro_export]
-macro_rules! ewrite {
-    ($arg:expr) => {{
-        #[allow(unused_must_use)]
-        {
-            let mut stm = $crate::io::print_impl::__SerialWriter::new(true);
-            stm.write_str($arg);
-        }
-    }};
-}
-
 /// Macro for printing a static string to the standard output, with a newline.
 ///
 /// Does not panic on failure to write - instead silently ignores errors.

--- a/packages/pros/src/lib.rs
+++ b/packages/pros/src/lib.rs
@@ -371,7 +371,6 @@ pub mod prelude {
     pub use crate::{
         async_robot,
         async_runtime::*,
-        dbg,
         devices::{
             adi::{
                 analog::{AdiAnalogIn, AdiAnalogOut},
@@ -397,13 +396,12 @@ pub mod prelude {
                 SmartDevice, SmartPort,
             },
         },
-        eprint, eprintln,
         error::PortError,
-        io::{BufRead, Read, Seek, Write},
+        io::{dbg, eprintln, print, println, BufRead, Read, Seek, Write},
         lcd::{buttons::Button, llemu_print, llemu_println, LcdError},
         os_task_local,
         pid::*,
-        print, println, sync_robot,
+        sync_robot,
         task::{delay, sleep, spawn},
         AsyncRobot, SyncRobot,
     };


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Removes potentially misleading named-macros from `pros::io`.
- This includes `write`, `ewrite`, `writeln`, and `ewriteln`, which have similarly names to the stuff in `core` and `std`, but do different things.
- Reexports the macros from the `io` module so people can call `pros::io::println` for example.

## Additional Context
- Eventually we should refactor `std::io` to use a closer API to `std::stdio` for internals to allow locks on `Stdin` and `Stdout` to write raw strings, but for now this will do.
- Breaking change (semver:major)