### PR TITLE
fix: pin rust toolchain version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2024-02-07
           override: true
 
       - name: Check
@@ -33,7 +33,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2024-02-07
           override: true
 
       - name: Setup | Install Rustfmt

--- a/packages/pros/src/lib.rs
+++ b/packages/pros/src/lib.rs
@@ -52,7 +52,7 @@
 //! You may have noticed the `#[derive(Default)]` attribute on these Robot structs.
 //! If you want to learn why, look at the docs for [`async_robot`] or [`sync_robot`].
 
-#![feature(error_in_core, stdsimd, negative_impls)]
+#![feature(error_in_core, negative_impls)]
 #![no_std]
 #![warn(
     missing_docs,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly"
-components = [ "rust-src" ]
-targets = [ "armv7a-none-eabi" ]
+channel = "nightly-2024-02-07"
+components = ["rust-src"]
+targets = ["armv7a-none-eabi"]


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This pins the rust toolchain version to prevent things from randomly breaking when rust updates. 

## Additional Context
- These are *only* non-code changes (e.g. documentation, README.md).