### PR TITLE
fix: avoid overflowing multiplications in draw_buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,6 @@ Before releasing:
 - Fixed Missing ERRNO and ADI config variants in pros-sys (#55)
 - Fixed incorrect error handling with `InertialSensor::status`. (#65)
 - `Controller::status` now handles errors by returning `Result<ControllerStatus, ControllerError>`. (**Breaking Change**) (#74)
-- Fixed a multiplication overflow in `screen::draw_buffer`. (#92)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Before releasing:
 - Fixed Missing ERRNO and ADI config variants in pros-sys (#55)
 - Fixed incorrect error handling with `InertialSensor::status`. (#65)
 - `Controller::status` now handles errors by returning `Result<ControllerStatus, ControllerError>`. (**Breaking Change**) (#74)
+- Fixed a multiplication overflow in `screen::draw_buffer`. (#92)
 
 ### Changed
 

--- a/packages/pros/src/devices/screen.rs
+++ b/packages/pros/src/devices/screen.rs
@@ -459,7 +459,8 @@ impl Screen {
             .into_iter()
             .map(|i| i.into_rgb().into())
             .collect::<Vec<_>>();
-        let expected_size = ((x1 - x0) * (y1 - y0)) as usize;
+        // Convert the coordinates to u32 to avoid overflows when multiplying.
+        let expected_size = ((x1 - x0) as u32 * (y1 - y0) as u32) as usize;
         if raw_buf.len() != expected_size {
             return Err(ScreenError::CopyBufferWrongSize {
                 buffer_size: raw_buf.len(),


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This fixed a panic caused by a faulty check in `screen::draw_buffer` that occurs when the number of pixels the region being drawn to is larger than `u16::MAX`.
## Additional Context
- I have tested these changes on a VEX V5 brain.
