### PR TITLE
fix: give a more descriptive error when compiling to unsupported targets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2024-02-07
+          toolchain: nightly-2024-02-07-armv7a-vexos-eabi
           override: true
 
       - name: Check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Before releasing:
 ### Fixed
 
 - Fix error handling and error type variats in ADI bindings
+- Give a better error when compiling for an unsupported target.
 
 ### Changed
 

--- a/packages/pros/src/lib.rs
+++ b/packages/pros/src/lib.rs
@@ -79,6 +79,10 @@ pub use pros_sys as __pros_sys;
 mod vexos_env;
 #[cfg(target_arch = "wasm32")]
 mod wasm_env;
+
+#[cfg(not(all(target_os = "vexos", target_arch = "wasm32")))]
+compile_error!("You are compiling pros-rs with an unsupported target! Supported targets are armv7a-vexos-eabi and wasm32. If you aren't sure what this means, please compile with `cargo pros`");
+
 #[macro_use]
 pub mod competition;
 pub mod color;


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This makes the error for compiling to an unsupported target much more clear.
Before this PR Rust would complain about not having a global allocator, now it errors telling you that you are compiling for an unsupported target and that `cargo pros` will fix it.

## Additional Context
- These are *only* non-code changes (e.g. documentation, README.md).