### PR TITLE
Fix: `AsyncRobot` only runs opcontrol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Before releasing:
 ### Fixed
 
 - Fix error handling and error type variats in ADI bindings
+- Fix `AsynRobot` only running opcontrol
 
 ### Changed
 

--- a/packages/pros/src/lib.rs
+++ b/packages/pros/src/lib.rs
@@ -209,7 +209,7 @@ macro_rules! __gen_async_exports {
         #[doc(hidden)]
         #[no_mangle]
         extern "C" fn autonomous() {
-            $crate::async_runtime::block_on(<$rbt as $crate::AsyncRobot>::opcontrol(unsafe {
+            $crate::async_runtime::block_on(<$rbt as $crate::AsyncRobot>::auto(unsafe {
                 ROBOT
                     .as_mut()
                     .expect("Expected initialize to run before auto")
@@ -220,7 +220,7 @@ macro_rules! __gen_async_exports {
         #[doc(hidden)]
         #[no_mangle]
         extern "C" fn disabled() {
-            $crate::async_runtime::block_on(<$rbt as $crate::AsyncRobot>::opcontrol(unsafe {
+            $crate::async_runtime::block_on(<$rbt as $crate::AsyncRobot>::disabled(unsafe {
                 ROBOT
                     .as_mut()
                     .expect("Expected initialize to run before disabled")
@@ -231,7 +231,7 @@ macro_rules! __gen_async_exports {
         #[doc(hidden)]
         #[no_mangle]
         extern "C" fn competition_initialize() {
-            $crate::async_runtime::block_on(<$rbt as $crate::AsyncRobot>::opcontrol(unsafe {
+            $crate::async_runtime::block_on(<$rbt as $crate::AsyncRobot>::comp_init(unsafe {
                 ROBOT
                     .as_mut()
                     .expect("Expected initialize to run before comp_init")


### PR DESCRIPTION
As much as we love opcontrol, it shouldn't be the only thing the robot can run.