### PR TITLE
fix: handle `EADDRINUSE` in smart port errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Before releasing:
 
 - Fix error handling and error type variats in ADI bindings
 - Fix `AsynRobot` only running opcontrol
+- Properly handle `EADDRINUSE` return for smart port errors (**Breaking Change**) (#97)
 
 ### Changed
 

--- a/packages/pros/src/error.rs
+++ b/packages/pros/src/error.rs
@@ -97,9 +97,12 @@ pub enum PortError {
     PortOutOfRange,
     /// The specified port couldn't be configured as the specified type.
     PortCannotBeConfigured,
+    /// The specified port is already being used or is mismatched.
+    AlreadyInUse,
 }
 
 map_errno!(PortError {
     ENXIO => Self::PortOutOfRange,
     ENODEV => Self::PortCannotBeConfigured,
+    EADDRINUSE => Self::AlreadyInUse,
 });


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
The PROS device registry can set EADDRINUSE in some cases if a device is mismatched or already registered on a port.

## Additional Context
Fixes a potential panic (and FPGA reset apparently).
