### PR TITLE
refactor: move device constants into associated struct `impl`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ Before releasing:
 - Renamed `AdiUltrasonic::value` to `AdiUltrasonic::distance` (**Breaking Change**) (#61).
 - Renamed `AdiEncoder::value` to `AdiEncoder::position` (**Breaking Change**) (#61).
 - Repurposed `AdiAnalogOut` as `AdiPwmOut` to correct match port output. (**Breaking Change**) (#90).
+- Moved most device-related constants into their associated struct `impl` (**Breaking Change**) (#98).
+- Renamed IMU_RESET_TIMEOUT to `InertialSensor::CALIBRATION_TIMEOUT` (**Breaking Change**) (#98).
 
 ### Removed
 

--- a/packages/pros/src/devices/adi/gyro.rs
+++ b/packages/pros/src/devices/adi/gyro.rs
@@ -7,12 +7,6 @@ use pros_sys::{ext_adi_gyro_t, PROS_ERR, PROS_ERR_F};
 use super::{AdiDevice, AdiDeviceType, AdiError, AdiPort};
 use crate::error::bail_on;
 
-/// The time it takes to calibrate an [`AdiGyro`].
-///
-/// The theoretical calibration time is 1024ms, but in practice this seemed to be the
-/// actual time that it takes.
-pub const GYRO_CALIBRATION_TIME: Duration = Duration::from_millis(1300);
-
 /// ADI gyro device.
 #[derive(Debug, Eq, PartialEq)]
 pub struct AdiGyro {
@@ -21,6 +15,12 @@ pub struct AdiGyro {
 }
 
 impl AdiGyro {
+    /// The time it takes to calibrate an [`AdiGyro`].
+    ///
+    /// The theoretical calibration time is 1024ms, but in practice this seemed to be the
+    /// actual time that it takes.
+    pub const CALIBRATION_TIME: Duration = Duration::from_millis(1300);
+
     /// Create a new gyro from an [`AdiPort`].
     ///
     /// If the given port has not previously been configured as a gyro, then this

--- a/packages/pros/src/devices/screen.rs
+++ b/packages/pros/src/devices/screen.rs
@@ -20,22 +20,12 @@ pub struct Screen {
     current_line: i16,
 }
 
-/// The maximum number of lines that can be visible on the screen at once.
-pub const SCREEN_MAX_VISIBLE_LINES: usize = 12;
-/// The height of a single line of text on the screen.
-pub const SCREEN_LINE_HEIGHT: i16 = 20;
-
-/// The horizontal resolution of the display.
-pub const SCREEN_HORIZONTAL_RESOLUTION: i16 = 480;
-/// The vertical resolution of the writable part of the display.
-pub const SCREEN_VERTICAL_RESOLUTION: i16 = 240;
-
 impl core::fmt::Write for Screen {
     fn write_str(&mut self, text: &str) -> core::fmt::Result {
         for character in text.chars() {
             if character == '\n' {
-                if self.current_line > (SCREEN_MAX_VISIBLE_LINES as i16 - 2) {
-                    self.scroll(0, SCREEN_LINE_HEIGHT)
+                if self.current_line > (Self::MAX_VISIBLE_LINES as i16 - 2) {
+                    self.scroll(0, Self::LINE_HEIGHT)
                         .map_err(|_| core::fmt::Error)?;
                 } else {
                     self.current_line += 1;
@@ -344,6 +334,18 @@ impl From<TouchState> for pros_sys::last_touch_e_t {
 }
 
 impl Screen {
+    /// The maximum number of lines that can be visible on the screen at once.
+    pub const MAX_VISIBLE_LINES: usize = 12;
+
+    /// The height of a single line of text on the screen.
+    pub const LINE_HEIGHT: i16 = 20;
+
+    /// The horizontal resolution of the display.
+    pub const HORIZONTAL_RESOLUTION: i16 = 480;
+
+    /// The vertical resolution of the writable part of the display.
+    pub const VERTICAL_RESOLUTION: i16 = 240;
+
     /// Create a new screen.
     ///
     /// # Safety
@@ -488,8 +490,8 @@ impl Screen {
         let error_box_rect = Rect::new(
             ERROR_BOX_MARGIN,
             ERROR_BOX_MARGIN,
-            SCREEN_HORIZONTAL_RESOLUTION - ERROR_BOX_MARGIN,
-            SCREEN_VERTICAL_RESOLUTION - ERROR_BOX_MARGIN,
+            Self::HORIZONTAL_RESOLUTION - ERROR_BOX_MARGIN,
+            Self::VERTICAL_RESOLUTION - ERROR_BOX_MARGIN,
         );
 
         self.fill(&error_box_rect, Rgb::RED)?;
@@ -509,7 +511,7 @@ impl Screen {
                         buffer.as_str(),
                         TextPosition::Point(
                             ERROR_BOX_MARGIN + ERROR_BOX_PADDING,
-                            ERROR_BOX_MARGIN + ERROR_BOX_PADDING + (line * SCREEN_LINE_HEIGHT),
+                            ERROR_BOX_MARGIN + ERROR_BOX_PADDING + (line * Self::LINE_HEIGHT),
                         ),
                         TextFormat::Small,
                     ),
@@ -526,7 +528,7 @@ impl Screen {
                 buffer.as_str(),
                 TextPosition::Point(
                     ERROR_BOX_MARGIN + ERROR_BOX_PADDING,
-                    ERROR_BOX_MARGIN + ERROR_BOX_PADDING + (line * SCREEN_LINE_HEIGHT),
+                    ERROR_BOX_MARGIN + ERROR_BOX_PADDING + (line * Self::LINE_HEIGHT),
                 ),
                 TextFormat::Small,
             ),

--- a/packages/pros/src/devices/smart/optical.rs
+++ b/packages/pros/src/devices/smart/optical.rs
@@ -8,14 +8,6 @@ use snafu::Snafu;
 use super::{SmartDevice, SmartDeviceType, SmartPort};
 use crate::error::{bail_on, map_errno, PortError};
 
-/// The smallest integration time you can set on an optical sensor.
-pub const MIN_INTEGRATION_TIME: Duration = Duration::from_millis(3);
-/// The largest integration time you can set on an optical sensor.
-pub const MAX_INTEGRATION_TIME: Duration = Duration::from_millis(712);
-
-/// The maximum value for the LED PWM.
-pub const MAX_LED_PWM: u8 = 100;
-
 /// Represents a smart port configured as a V5 optical sensor
 #[derive(Debug, Eq, PartialEq)]
 pub struct OpticalSensor {
@@ -24,6 +16,15 @@ pub struct OpticalSensor {
 }
 
 impl OpticalSensor {
+    /// The smallest integration time you can set on an optical sensor.
+    pub const MIN_INTEGRATION_TIME: Duration = Duration::from_millis(3);
+
+    /// The largest integration time you can set on an optical sensor.
+    pub const MAX_INTEGRATION_TIME: Duration = Duration::from_millis(712);
+
+    /// The maximum value for the LED PWM.
+    pub const MAX_LED_PWM: u8 = 100;
+
     /// Creates a new inertial sensor from a smart port index.
     ///
     /// Gesture detection features can be optionally enabled, allowing the use of [`Self::last_gesture_direction()`] and [`Self::last_gesture_direction()`].
@@ -54,7 +55,7 @@ impl OpticalSensor {
 
     /// Sets the pwm value of the White LED. Valid values are in the range `0` `100`.
     pub fn set_led_pwm(&mut self, value: u8) -> Result<(), OpticalError> {
-        if value > MAX_LED_PWM {
+        if value > Self::MAX_LED_PWM {
             return Err(OpticalError::InvalidLedPwm);
         }
         unsafe {
@@ -86,7 +87,7 @@ impl OpticalSensor {
     /// https://www.vexforum.com/t/v5-optical-sensor-refresh-rate/109632/9 for
     /// more information.
     pub fn set_integration_time(&mut self, time: Duration) -> Result<(), OpticalError> {
-        if time < MIN_INTEGRATION_TIME || time > MAX_INTEGRATION_TIME {
+        if time < Self::MIN_INTEGRATION_TIME || time > Self::MAX_INTEGRATION_TIME {
             return Err(OpticalError::InvalidIntegrationTime);
         }
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
e.g. `IMU_MIN_DATA_RATE` -> `InertialSensor::MIN_DATA_RATE`. Makes for a cleaner API.

## Additional Context
None