### PR TITLE
refactor: make `AdiEncoder` return `Position`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Before releasing:
   - Renamed `Motor::get_state` to `Motor::status`.
 - Status structs containing device bits now use the `bitflags!` crate. (**Breaking Change**) (#66)
 - Renamed `InertialSensor::calibrating` to `InertialSensor::calibrating` (**Breaking CHange**) (#66)
-- AdiEncoder now returns `Position` rather than just degrees.
+- AdiEncoder now returns `Position` rather than just degrees (**Breaking Change**) (#106).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Before releasing:
   - Renamed `Motor::get_state` to `Motor::status`.
 - Status structs containing device bits now use the `bitflags!` crate. (**Breaking Change**) (#66)
 - Renamed `InertialSensor::calibrating` to `InertialSensor::calibrating` (**Breaking CHange**) (#66)
+- AdiEncoder now returns `Position` rather than just degrees.
 
 ### Removed
 

--- a/packages/pros-devices/src/adi/encoder.rs
+++ b/packages/pros-devices/src/adi/encoder.rs
@@ -3,9 +3,8 @@
 use pros_core::bail_on;
 use pros_sys::{ext_adi_encoder_t, PROS_ERR};
 
-use crate::Position;
-
 use super::{AdiDevice, AdiDeviceType, AdiError, AdiPort};
+use crate::Position;
 
 /// ADI encoder device.
 /// Requires two adi ports.
@@ -52,9 +51,7 @@ impl AdiEncoder {
 
     /// Gets the number of ticks recorded by the encoder.
     pub fn position(&self) -> Result<Position, AdiError> {
-        let degrees = bail_on!(PROS_ERR, unsafe {
-            pros_sys::adi_encoder_get(self.raw)
-        });
+        let degrees = bail_on!(PROS_ERR, unsafe { pros_sys::adi_encoder_get(self.raw) });
 
         Ok(Position::from_degrees(degrees as f64))
     }

--- a/packages/pros-devices/src/adi/encoder.rs
+++ b/packages/pros-devices/src/adi/encoder.rs
@@ -3,6 +3,8 @@
 use pros_core::bail_on;
 use pros_sys::{ext_adi_encoder_t, PROS_ERR};
 
+use crate::Position;
+
 use super::{AdiDevice, AdiDeviceType, AdiError, AdiPort};
 
 /// ADI encoder device.
@@ -49,10 +51,12 @@ impl AdiEncoder {
     }
 
     /// Gets the number of ticks recorded by the encoder.
-    pub fn position(&self) -> Result<i32, AdiError> {
-        Ok(bail_on!(PROS_ERR, unsafe {
+    pub fn position(&self) -> Result<Position, AdiError> {
+        let degrees = bail_on!(PROS_ERR, unsafe {
             pros_sys::adi_encoder_get(self.raw)
-        }))
+        });
+
+        Ok(Position::from_degrees(degrees as f64))
     }
 }
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Makes `AdiEncoder` return `Position` rather than just i32 degrees.

## Additional Context
Still need to refactor Position to use dynamic TPR amounts.