### PR TITLE
fix: disallow unsafe code in robot macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Before releasing:
   - Renamed `Motor::get_state` to `Motor::status`.
 - Status structs containing device bits now use the `bitflags!` crate. (**Breaking Change**) (#66)
 - Renamed `InertialSensor::calibrating` to `InertialSensor::calibrating` (**Breaking CHange**) (#66)
-- AdiEncoder now returns `Position` rather than just degrees.
+- AdiEncoder now returns `Position` rather than just degrees (**Breaking Change**) (#106).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Before releasing:
 ### Fixed
 
 - `pros_sys` bindings to the Motors C API now takes the correct port type (`i8`) as of PROS 4 (**Breaking Change**) (#66).
+- Fixed the unintended `unsafe` context present in the `sync_robot` and `async_robot` family of macros (**Breaking Change**) (#107).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Before releasing:
   - Renamed `Motor::get_state` to `Motor::status`.
 - Status structs containing device bits now use the `bitflags!` crate. (**Breaking Change**) (#66)
 - Renamed `InertialSensor::calibrating` to `InertialSensor::calibrating` (**Breaking CHange**) (#66)
+- AdiEncoder now returns `Position` rather than just degrees.
 
 ### Removed
 

--- a/packages/pros-async/src/lib.rs
+++ b/packages/pros-async/src/lib.rs
@@ -185,8 +185,9 @@ macro_rules! async_robot {
 
         #[no_mangle]
         extern "C" fn initialize() {
+            let robot = Default::default();
             unsafe {
-                ROBOT = Some(Default::default());
+                ROBOT = Some(robot);
             }
         }
     };
@@ -195,8 +196,9 @@ macro_rules! async_robot {
 
         #[no_mangle]
         extern "C" fn initialize() {
+            let robot = $init;
             unsafe {
-                ROBOT = Some($init);
+                ROBOT = Some(robot);
             }
         }
     };

--- a/packages/pros-devices/src/adi/encoder.rs
+++ b/packages/pros-devices/src/adi/encoder.rs
@@ -3,9 +3,8 @@
 use pros_core::bail_on;
 use pros_sys::{ext_adi_encoder_t, PROS_ERR};
 
-use crate::Position;
-
 use super::{AdiDevice, AdiDeviceType, AdiError, AdiPort};
+use crate::Position;
 
 /// ADI encoder device.
 /// Requires two adi ports.
@@ -52,9 +51,7 @@ impl AdiEncoder {
 
     /// Gets the number of ticks recorded by the encoder.
     pub fn position(&self) -> Result<Position, AdiError> {
-        let degrees = bail_on!(PROS_ERR, unsafe {
-            pros_sys::adi_encoder_get(self.raw)
-        });
+        let degrees = bail_on!(PROS_ERR, unsafe { pros_sys::adi_encoder_get(self.raw) });
 
         Ok(Position::from_degrees(degrees as f64))
     }

--- a/packages/pros-devices/src/adi/encoder.rs
+++ b/packages/pros-devices/src/adi/encoder.rs
@@ -3,6 +3,8 @@
 use pros_core::bail_on;
 use pros_sys::{ext_adi_encoder_t, PROS_ERR};
 
+use crate::Position;
+
 use super::{AdiDevice, AdiDeviceType, AdiError, AdiPort};
 
 /// ADI encoder device.
@@ -49,10 +51,12 @@ impl AdiEncoder {
     }
 
     /// Gets the number of ticks recorded by the encoder.
-    pub fn position(&self) -> Result<i32, AdiError> {
-        Ok(bail_on!(PROS_ERR, unsafe {
+    pub fn position(&self) -> Result<Position, AdiError> {
+        let degrees = bail_on!(PROS_ERR, unsafe {
             pros_sys::adi_encoder_get(self.raw)
-        }))
+        });
+
+        Ok(Position::from_degrees(degrees as f64))
     }
 }
 

--- a/packages/pros-sync/src/lib.rs
+++ b/packages/pros-sync/src/lib.rs
@@ -123,8 +123,9 @@ macro_rules! sync_robot {
 
         #[no_mangle]
         extern "C" fn initialize() {
+            let robot = Default::default();
             unsafe {
-                ROBOT = Some(Default::default());
+                ROBOT = Some(robot);
             }
         }
     };
@@ -133,8 +134,9 @@ macro_rules! sync_robot {
 
         #[no_mangle]
         extern "C" fn initialize() {
+            let robot = $init;
             unsafe {
-                ROBOT = Some($init);
+                ROBOT = Some(robot);
             }
         }
     };


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Explained here:
![image](https://github.com/pros-rs/pros-rs/assets/42101043/07db45ba-0003-4795-a64c-b3c38d3aeda1)
