### PR TITLE
fix: add `Controller` to prelude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Before releasing:
   - Added support for getting motor fault flags (e.g. over-temperature, over-current, H-bridge faults).
   - Added support for internal motor PID tuning. Feature gated behind `dangerous_motor_tuning`, as this can cause hardware damage and is not recommended.
   - Added various constants for convenience around `Motor` and `Gearset`.
-
+- Added `Controller` API to the `pros::prelude` module. (#108)
 ### Fixed
 
 - `pros_sys` bindings to the Motors C API now takes the correct port type (`i8`) as of PROS 4 (**Breaking Change**) (#66).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Before releasing:
   - Added support for internal motor PID tuning. Feature gated behind `dangerous_motor_tuning`, as this can cause hardware damage and is not recommended.
   - Added various constants for convenience around `Motor` and `Gearset`.
 - Added `Controller` API to the `pros::prelude` module. (#108)
+
 ### Fixed
 
 - `pros_sys` bindings to the Motors C API now takes the correct port type (`i8`) as of PROS 4 (**Breaking Change**) (#66).

--- a/packages/pros/src/lib.rs
+++ b/packages/pros/src/lib.rs
@@ -97,10 +97,10 @@ pub mod prelude {
             AdiDevice, AdiPort,
         },
         color::Rgb,
+        controller::Controller,
         peripherals::{DynamicPeripherals, Peripherals},
         position::Position,
         screen::{Circle, Line, Rect, Screen, Text, TextFormat, TextPosition, TouchState},
-        controller::Controller,
         smart::{
             distance::DistanceSensor,
             expander::AdiExpander,

--- a/packages/pros/src/lib.rs
+++ b/packages/pros/src/lib.rs
@@ -100,6 +100,7 @@ pub mod prelude {
         peripherals::{DynamicPeripherals, Peripherals},
         position::Position,
         screen::{Circle, Line, Rect, Screen, Text, TextFormat, TextPosition, TouchState},
+        controller::Controller,
         smart::{
             distance::DistanceSensor,
             expander::AdiExpander,


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Adds `Controller` to `pros::prelude` which was missing and pretty commonly used.